### PR TITLE
Single starter script: nanometa-live

### DIFF
--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -32,5 +32,11 @@ jobs:
     - name: Check nanometa-new version
       run: nanometa-new --version 
 
-    - name: Check nanometa-pipe version
-      run: nanometa-pipe --version 
+    - name: Check nanometa-backend version
+      run: nanometa-backend --version
+
+    - name: Check nanometa-gui version
+      run: nanometa-gui--version
+
+    - name: Check nanometa-live version
+      run: nanometa-live --version

--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -36,7 +36,7 @@ jobs:
       run: nanometa-backend --version
 
     - name: Check nanometa-gui version
-      run: nanometa-gui--version
+      run: nanometa-gui --version
 
     - name: Check nanometa-live version
       run: nanometa-live --version

--- a/nanometa_live/gui_scripts/create_gauge.py
+++ b/nanometa_live/gui_scripts/create_gauge.py
@@ -1,16 +1,28 @@
 import plotly.graph_objects as go
 import yaml
 import math
+import os
 
-def create_gauge(value = 0): # value = highest log10 reads
+def create_gauge(value = 0, config_file_path='config.yaml'): # value = highest log10 reads
     """
     Creates a plotly gauge from a float; a species of interests log10 read value.
     Coloring: yellow = warning, red = danger.
     Ranges adjustable in config file.
     """
-    # load config file contents
-    with open('config.yaml', 'r')as cf:
-        config_content = yaml.safe_load(cf)
+
+    # Check if the config file exists
+    if not os.path.exists(config_file_path):
+        print(f"Error: Config file '{config_file_path}' not found.")
+        return None
+
+    # Load config file variables
+    try:
+        with open(config_file_path, 'r') as cf:
+            config_content = yaml.safe_load(cf)
+    except Exception as e:
+        print(f"Error: An issue occurred while reading the config file. Details: {e}")
+        return None
+
         
     # defining color ranges of the graph:
     # if any species have reads above Warning Lower Limit: yellow

--- a/nanometa_live/gui_scripts/icicle_sunburst_data.py
+++ b/nanometa_live/gui_scripts/icicle_sunburst_data.py
@@ -2,17 +2,27 @@ from nanometa_live.gui_scripts.domain_filtering import domain_filtering
 from nanometa_live.gui_scripts.icicle_sunburst_matrix import icicle_sunburst_matrix
 from nanometa_live.gui_scripts.get_icicle_data import get_icicle_data
 import yaml
+import os
 
-def icicle_sunburst_data(raw_df, domains, count = 10):
+def icicle_sunburst_data(raw_df, domains, count = 10, config_file_path='config.yaml'):
     """
     Creates the data in the format needed for plotly sunsickle charts.
     Data format for sunburst and icicle is identical.
     """
     
-    # Load config file variables.
-    with open('config.yaml', 'r') as cf:
-        config_contents = yaml.safe_load(cf)
-        
+    # Check if the config file exists
+    if not os.path.exists(config_file_path):
+        print(f"Error: Config file '{config_file_path}' not found.")
+        return None
+
+    # Load config file variables
+    try:
+        with open(config_file_path, 'r') as cf:
+            config_contents = yaml.safe_load(cf)
+    except Exception as e:
+        print(f"Error: An issue occurred while reading the config file. Details: {e}")
+        return None
+
     # Gets the tax letters from the config file.
     config_letters = config_contents['taxonomic_hierarchy_letters']
     

--- a/nanometa_live/nanometa_live.py
+++ b/nanometa_live/nanometa_live.py
@@ -1,0 +1,55 @@
+import argparse
+import subprocess
+import time
+import logging
+from nanometa_live import __version__  # Import the version number
+
+def setup_logging():
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description='Starting the Nanometa Live pipeline.')
+    parser.add_argument('--config', default='config.yaml',
+                        help='Path to the configuration file. Default is config.yaml.')
+    parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}',
+                        help="Show the current version of the script.")
+    parser.add_argument('-p', '--path', default='', help="The path to the project directory.")
+    return parser.parse_args()
+
+def start_processes(commands, args):
+    processes = []
+    for cmd in commands:
+        cmd_with_args = f"{cmd} --config {args.config} -p {args.path}"
+        logging.info(f"Starting process: {cmd_with_args}")
+        process = subprocess.Popen(cmd_with_args, shell=True)
+        processes.append(process)
+    return processes
+
+def terminate_processes(processes):
+    for process in processes:
+        logging.info(f'Terminating processes: {process}')
+        process.terminate()
+        process.wait()
+
+def main():
+    setup_logging()
+    args = parse_arguments()
+    commands = ['nanometa-backend', 'nanometa-gui']
+
+    try:
+        processes = start_processes(commands, args)
+
+        while True:
+            time.sleep(0.1)
+
+    except KeyboardInterrupt:
+        terminate_processes(processes)
+
+    except Exception as e:
+        logging.error(f'Error: {e}')
+
+    finally:
+        logging.info('Processes terminated')
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,9 @@ setup(
                       ['nanometa-sim = nanometa_live.nanopore_simulator:nano_sim', # nanopore simulator
                        'nanometa-new = nanometa_live.create_new_project:create_new', # create new project
                        'nanometa-blastdb = nanometa_live.build_blast_db:build_blast', # create blast validation databases
-                       'nanometa-pipe = nanometa_live.nanometa_backend:main', # run backend pipeline
-                       'nanometa = nanometa_live.nanometa_gui:run_app' # run gui
+                       'nanometa-backend = nanometa_live.nanometa_backend:main', # run backend pipeline
+                       'nanometa-gui = nanometa_live.nanometa_gui:run_app', # run gui
+                       'nanometa-live = nanometa_live.nanometa_live:main'
                        ]
                       },
       # Makes sure the files are found after install.


### PR DESCRIPTION
This introduces a unified launcher script, "nanometa-live," which initiates both the nanometa-backend and nanometa-gui services. It also enhances configurability by replacing hard-coded references to config.yaml with argument-passing mechanisms.