### PR TITLE
Add Termination Logic to fetch_species_data Function for Zero Results or Errors

### DIFF
--- a/nanometa_live/nanometa_prepare.py
+++ b/nanometa_live/nanometa_prepare.py
@@ -124,9 +124,12 @@ def fetch_species_data(search_str: str, db: str, page: int = 1, itemsPerPage: in
             rows = json.loads(response.text)['rows']
             num_rows = len(rows)  # Get the number of rows
 
-            # Log number of fetched rows and success
-            logging.info(f"Successfully fetched {num_rows} rows for {search_str} from {db}.")
+            # Stop if no rows are returned
+            if num_rows == 0:
+                logging.warning(f"No data fetched for {search_str} from {db}. Stopping function.")
+                sys.exit("Terminating the program due to zero fetched rows.")  # Terminate the program
 
+            logging.info(f"Successfully fetched {num_rows} rows for {search_str} from {db}.")
 
             # Log details of fetched data for debugging
             for row in rows:
@@ -134,14 +137,15 @@ def fetch_species_data(search_str: str, db: str, page: int = 1, itemsPerPage: in
                 gid = row.get('gid', 'N/A')
                 gtdb_rep = row.get('isGtdbSpeciesRep', 'N/A')
                 ncbi_type = row.get('isGtdbSpeciesRep', 'N/A')
-                #logging.info(f"Seatch string: {search_str}, Fetched row details: NCBI organism: {ncbiorgname}, GID: {gid}, GTDB reprentative: {gtdb_rep}, NCBI type strain: {ncbi_type}")
+                #logging.info(f"Search string: {search_str}, Fetched row details: NCBI organism: {ncbiorgname}, GID: {gid}, GTDB representative: {gtdb_rep}, NCBI type strain: {ncbi_type}")
             return rows
         else:
             logging.warning(f"Failed to get data for {search_str} from {db}. HTTP Status Code: {response.status_code}")
             return []
     except Exception as e:
         logging.error(f"An error occurred while fetching data: {e}")
-        return []
+        sys.exit(f"Terminating the program due to an error: {e}")  # Terminate the program
+
 
 
 def filter_exact_match(rows: list, search_str: str, db: str) -> list:


### PR DESCRIPTION
This PR adds functionality to the `fetch_species_data` function to terminate the program when zero rows are fetched from the database or an error occurs during the fetch operation. Previously, the function would just log a warning and continue execution, which could potentially lead to issues later in the pipeline. Now, the function will log an error or warning message and terminate the program, providing a safer failure mechanism.

#### Changes:

1. Add a check for zero fetched rows, logging a warning and terminating the program if true.
2. Add program termination on exceptions with a logged error message.

