### PR TITLE
Enhancements to `file_utils.py` and `transform_utils.py` to implement mode gtdb-file

### DIFF
--- a/nanometa_live/helpers/transform_utils.py
+++ b/nanometa_live/helpers/transform_utils.py
@@ -91,3 +91,27 @@ def parse_to_table_with_taxid(filtered_data: dict) -> pd.DataFrame:
     return parsed_df
 
 
+def add_taxid_to_results(filtered_results: pd.DataFrame, species_taxid_dict: Dict[str, int]) -> pd.DataFrame:
+    """
+    Adds tax IDs to the filtered_results DataFrame based on the species names.
+
+    Parameters:
+        filtered_results (pd.DataFrame): The DataFrame containing the filtered results.
+        species_taxid_dict (Dict[str, int]): Dictionary mapping species names to tax IDs.
+
+    Returns:
+        pd.DataFrame: DataFrame with a new 'Tax_ID' column.
+    """
+    logging.info("Adding tax IDs to filtered results.")
+
+    # Create a new column 'Tax_ID' by mapping species names to tax IDs
+    filtered_results['Tax_ID'] = filtered_results['Species'].map(species_taxid_dict)
+
+    # Check if all species have corresponding tax IDs
+    missing_taxids = filtered_results[filtered_results['Tax_ID'].isnull()]['Species'].unique()
+    if len(missing_taxids) > 0:
+        logging.error(f"Could not find tax IDs for the following species: {', '.join(missing_taxids)}. Aborting.")
+        raise ValueError("Missing tax IDs for some species.")
+
+    logging.info("Successfully added tax IDs to filtered results.")
+    return filtered_results


### PR DESCRIPTION
#### Summary:

This PR introduces several key enhancements to the `file_utils.py` and `transform_utils.py` files to better handle GTDB metadata. The aim is to streamline the GTDB file downloading, reading, and processing steps, particularly when used in conjunction with other modes in `nanometa_prepare.py`.

#### Changes:

1. **Download GTDB Metadata:** Implemented a function `download_gtdb_metadata()` to download GTDB metadata files and corrected the directory paths.

2. **Read and Process GTDB Metadata:** Added a function `read_and_process_gtdb_metadata()` to read the GTDB metadata file, filter it based on Kraken2 taxonomy, and return a DataFrame. The function also includes additional logging to show the number of rows before and after filtering.

3. **Adding Tax IDs:** Introduced `add_taxid_to_results()` in `transform_utils.py` to map species names to tax IDs and add this information as a new column in the DataFrame.

4. **Main Script Update:** Included calls to these new functions in `nanometa_prepare.py` to integrate them into the existing workflow.
