### PR TITLE
Make Project Path Argument Required in `nanometa_new.py`

### DIFF
--- a/nanometa_live/nanometa_new.py
+++ b/nanometa_live/nanometa_new.py
@@ -34,7 +34,7 @@ def main():
 
     parser = argparse.ArgumentParser()
     # Main config
-    parser.add_argument('-p', '--path', help="The path to the project directory.")
+    parser.add_argument('-p', '--path', required=True, help="The path to the project directory.")
     parser.add_argument('-c', '--config', default="config.yaml", help="The name of the config file. Default is 'config.yaml'.")
 
     # GUI Config


### PR DESCRIPTION
#### Description:

This pull request addresses the need to make the project path argument (`-p`, `--path`) a required parameter when running `nanometa_new.py`. Previously, the script would execute without this crucial information, leading to potential issues and a lack of clarity for the user.