### PR TITLE
Refactoring External Database Options and Setup Script Modifications

### DIFF
--- a/nanometa_live/config.yaml
+++ b/nanometa_live/config.yaml
@@ -123,12 +123,6 @@ kraken_memory_mapping: "--memory-mapping"
 external_kraken2_db:
 
 external_kraken2_info:
-  MinusB:
-    description: "Refeq archaea, viral, plasmid, human, UniVec_Core"
-    database_url: "https://genome-idx.s3.amazonaws.com/kraken/k2_minusb_20231009.tar.gz"
-    inspect_url: "https://genome-idx.s3.amazonaws.com/kraken/minusb_20231009/inspect.txt"
-    kraken_taxonomy: "ncbi"
-
   Standard:
     description: "Refeq archaea, bacteria, viral, plasmid, human1, UniVec_Core"
     database_url: "https://genome-idx.s3.amazonaws.com/kraken/k2_standard_20231009.tar.gz"
@@ -189,17 +183,23 @@ external_kraken2_info:
     inspect_url: "https://genome-idx.s3.amazonaws.com/kraken/nt_20230502/inspect.txt"
     kraken_taxonomy: "ncbi"
 
-  EuPathDB:
-    description: "Eukaryotic pathogen genomes with contaminants removed"
-    database_url: "https://genome-idx.s3.amazonaws.com/kraken/k2_eupathdb48_20230407.tar.gz"
-    inspect_url: "https://genome-idx.s3.amazonaws.com/kraken/k2_eupathdb48_20230407/kraken2inspect_output.txt"
-    kraken_taxonomy: "ncbi"
-
-  Viral:
-    description: "Refeq viral"
-    database_url: "https://genome-idx.s3.amazonaws.com/kraken/k2_viral_20231009.tar.gz"
-    inspect_url: "https://genome-idx.s3.amazonaws.com/kraken/viral_20231009/inspect.txt"
-    kraken_taxonomy: "ncbi"
+  # EuPathDB:
+  #   description: "Eukaryotic pathogen genomes with contaminants removed"
+  #   database_url: "https://genome-idx.s3.amazonaws.com/kraken/k2_eupathdb48_20230407.tar.gz"
+  #   inspect_url: "https://genome-idx.s3.amazonaws.com/kraken/k2_eupathdb48_20230407/kraken2inspect_output.txt"
+  #   kraken_taxonomy: "ncbi"
+  #
+  # Viral:
+  #   description: "Refeq viral"
+  #   database_url: "https://genome-idx.s3.amazonaws.com/kraken/k2_viral_20231009.tar.gz"
+  #   inspect_url: "https://genome-idx.s3.amazonaws.com/kraken/viral_20231009/inspect.txt"
+  #   kraken_taxonomy: "ncbi"
+  #
+  # MinusB:
+  #   description: "Refeq archaea, viral, plasmid, human, UniVec_Core"
+  #   database_url: "https://genome-idx.s3.amazonaws.com/kraken/k2_minusb_20231009.tar.gz"
+  #   inspect_url: "https://genome-idx.s3.amazonaws.com/kraken/minusb_20231009/inspect.txt"
+  #   kraken_taxonomy: "ncbi"
 
 ########## Quality and Validation Settings ###################################
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
       entry_points = {'console_scripts':
                       ['nanometa-sim = nanometa_live.nanopore_simulator:nano_sim', # nanopore simulator
                        'nanometa-new = nanometa_live.nanometa_new:main', # create new project
-                       'nanometa-blastdb = nanometa_live.build_blast_db:build_blast', # create blast validation databases
                        'nanometa-backend = nanometa_live.nanometa_backend:main', # run backend pipeline
                        'nanometa-gui = nanometa_live.nanometa_gui:run_app', # run gui
                        'nanometa-live = nanometa_live.nanometa_runner:main',  # wrapper to run both backend and GUI.


### PR DESCRIPTION
This pull request introduces significant changes to the `config.yaml` and `setup.py` files in the `nanometa_live` project, streamlining external database options and refining the setup process.

#### Changes in `config.yaml`
1. **External Database Options**:
   - Commented out the `MinusB`, `EuPathDB`, and `Viral` database entries in `external_kraken2_info`. This change simplifies the external database selection, focusing on the most utilized databases.

#### Changes in `setup.py`
1. **Setup Script Refactoring**:
   - Removed the `nanometa-blastdb` command from `entry_points` in `setup.py`. This adjustment streamlines the setup process, focusing on core functionalities.
