### PR TITLE
Enhance Accessibility of Nanometa GUI by Enabling External Network Access

### DIFF
--- a/nanometa_live/nanometa_gui.py
+++ b/nanometa_live/nanometa_gui.py
@@ -1811,7 +1811,7 @@ def run_app():
     '''
     # A unique port specifiable in config.
     # Debug=True means it updates as you make changes in this script.
-    app.run(debug=True, port=int(config_contents['gui_port']))
+    app.run(debug=True, host="0.0.0.0", port=int(config_contents['gui_port']))
 if __name__ == "__main__":
     # The run_app makes it run as an entry point (bash command).
     run_app()


### PR DESCRIPTION

**Details:**
The existing code in `nanometa_gui.py` only allowed the Dash application to be accessible locally, as it was binding to the default `127.0.0.1` interface. This limitation hindered the ability to access the GUI from other machines or within a Docker container setup.

The proposed change (`app.run(debug=True, host="0.0.0.0", port=int(config_contents['gui_port']))`) explicitly sets the host to `0.0.0.0`. This adjustment ensures that the application listens on all network interfaces, thereby facilitating access from external IPs and within containerized environments.

**Implications:**
- **Enhanced Accessibility**: The GUI becomes accessible from any machine in the network, not just localhost.
- **Container Compatibility**: This change is particularly beneficial for deployment within Docker or Singularity containers, where access is often required from outside the container.

