### PR TITLE
eval/gui-mode-signposting

### DIFF
--- a/nanometa_live/app/callbacks.py
+++ b/nanometa_live/app/callbacks.py
@@ -1264,6 +1264,72 @@ def register_core_callbacks(app: Dash, backend_manager: BackendManager):
     # Auto-Navigation on Analysis Completion
     # ========================================================================
 
+    # Track the last error string we surfaced to avoid re-toasting
+    # the same message on every status poll. Status writes are
+    # serialised in BackendManager so this dict-of-one is sufficient.
+    _last_analyze_error = {"text": None}
+
+    @app.callback(
+        Output("toast-message", "data", allow_duplicate=True),
+        Input("backend-status", "data"),
+        State("app-config", "data"),
+        prevent_initial_call=True,
+    )
+    def emit_analyze_error_toast(status, config):
+        """Surface pipeline errors as a toast that names the path the
+        Kraken2 loader scanned and the glob patterns it tried.
+
+        The previous experience was a generic ``Pipeline encountered
+        errors`` message in the status bar; the operator had no way to
+        tell whether the failure was at launch, mid-pipeline, or in
+        the dashboard's loader. Naming the absolute path and the glob
+        patterns turns a 'where did it look?' question into something
+        the operator can verify with ``ls``.
+        """
+        if not status or status.get("pipeline_status") != "error":
+            return no_update
+        errors = status.get("errors") or []
+        if not errors:
+            return no_update
+        error_text = "; ".join(errors)
+        if error_text == _last_analyze_error["text"]:
+            return no_update
+        _last_analyze_error["text"] = error_text
+
+        main_dir = ""
+        if config:
+            main_dir = (
+                config.get("results_output_directory")
+                or config.get("main_dir")
+                or ""
+            )
+
+        try:
+            from nanometa_live.core.utils.classification_loaders import (
+                describe_kraken_scan_locations,
+            )
+            scan = describe_kraken_scan_locations(main_dir)
+        except Exception:
+            scan = {"kraken_dir": "", "exists": False, "patterns": []}
+
+        kraken_dir = scan.get("kraken_dir") or "(results directory not configured)"
+        exists_label = (
+            "(directory present)" if scan.get("exists") else "(directory missing)"
+        )
+        patterns = scan.get("patterns") or []
+        patterns_text = ", ".join(patterns) if patterns else "(none)"
+
+        message = (
+            f"{error_text}\n\n"
+            f"Loader scan path: {kraken_dir} {exists_label}\n"
+            f"Glob patterns tried: {patterns_text}"
+        )
+        return {
+            "type": "error",
+            "title": "Analysis error",
+            "message": message,
+        }
+
     @app.callback(
         [
             Output("tabs", "active_tab", allow_duplicate=True),

--- a/nanometa_live/app/components/config_form.py
+++ b/nanometa_live/app/components/config_form.py
@@ -118,19 +118,38 @@ def create_config_form():
                         dbc.Select(
                             id="sample-handling-input",
                             options=[
-                                {"label": "Single sample (all files = 1 sample)", "value": "single_sample"},
-                                {"label": "Per file (each file = 1 sample)", "value": "per_file"},
-                                {"label": "By barcode (subdirectories)", "value": "by_barcode"}
+                                {
+                                    "label": "single_sample - one merged sample (flat folder, e.g. nanorunner singleplex)",
+                                    "value": "single_sample",
+                                },
+                                {
+                                    "label": "per_file - each file is its own sample (flat folder)",
+                                    "value": "per_file",
+                                },
+                                {
+                                    "label": "by_barcode - multiplexed (barcode01/, barcode02/, ...)",
+                                    "value": "by_barcode",
+                                },
                             ],
                             value="single_sample"
                         ),
                         dbc.Tooltip(
-                            "Single sample: All FASTQ files belong to one sample. "
-                            "Per file: Each file is a separate sample. "
-                            "By barcode: Files in barcode01/, barcode02/ etc. are separate samples.",
+                            "single_sample: all FASTQ files in one flat folder are pooled into a single sample "
+                            "(matches nanorunner singleplex output). "
+                            "per_file: each FASTQ file in a flat folder is its own sample. "
+                            "by_barcode: each barcode<NN>/ subdirectory is one sample (multiplexed run).",
                             target="sample-handling-info"
                         ),
-                        dbc.FormText("How to group input files into samples")
+                        # Auto-detect preview line, populated by a callback
+                        # in config_tab.py that watches the Nanopore Sequence
+                        # Data Folder input and the sample-handling selection.
+                        # Empty until a path is entered.
+                        html.Div(
+                            id="sample-handling-autodetect",
+                            className="mt-1",
+                            children="",
+                        ),
+                        dbc.FormText("How to group input files into samples"),
                     ], md=4),
                     dbc.Col([
                         dbc.Label([

--- a/nanometa_live/app/tabs/config_tab.py
+++ b/nanometa_live/app/tabs/config_tab.py
@@ -1439,6 +1439,97 @@ def register_config_callbacks(app: Dash, backend_manager: BackendManager):
             )
 
     @app.callback(
+        Output("sample-handling-autodetect", "children"),
+        [
+            Input("nanopore-dir-input", "value"),
+            Input("sample-handling-input", "value"),
+        ],
+        prevent_initial_call=False,
+    )
+    def update_sample_handling_autodetect(nanopore_dir, current_mode):
+        """Render a one-line preview of the detected directory layout.
+
+        Helps the operator pick a sample-handling mode that matches the
+        actual input folder. The detection is delegated to
+        ``core.utils.auto_detect.detect_sample_handling`` so the rule
+        cannot drift from the validation path used at Apply Settings.
+        """
+        if not nanopore_dir or not str(nanopore_dir).strip():
+            return ""
+
+        path = os.path.expanduser(str(nanopore_dir).strip())
+        if not os.path.isdir(path):
+            return html.Small(
+                [
+                    html.I(className="bi bi-dash-circle me-1"),
+                    "Auto-detect: enter an existing folder to preview the layout.",
+                ],
+                className="text-muted",
+            )
+
+        try:
+            import glob as _glob
+            from nanometa_live.core.utils.auto_detect import (
+                detect_sample_handling,
+                find_sample_subdirs,
+                is_barcode_named,
+            )
+
+            detected_mode, _reason = detect_sample_handling(path)
+            sample_dirs = find_sample_subdirs(path)
+            flat_fastqs = (
+                _glob.glob(os.path.join(path, "*.fastq*"))
+                + _glob.glob(os.path.join(path, "*.fq*"))
+            )
+
+            if sample_dirs:
+                conventional = [d for d in sample_dirs if is_barcode_named(d.name)]
+                layout_label = "barcoded" if conventional else "subdirectory-per-sample"
+                count_label = (
+                    f"{len(sample_dirs)} sample folder"
+                    + ("s" if len(sample_dirs) != 1 else "")
+                )
+            elif flat_fastqs:
+                layout_label = "flat"
+                count_label = (
+                    f"{len(flat_fastqs)} FASTQ file"
+                    + ("s" if len(flat_fastqs) != 1 else "")
+                )
+            else:
+                return html.Small(
+                    [
+                        html.I(className="bi bi-exclamation-circle me-1"),
+                        "Auto-detect: no FASTQ files or sample subdirectories found.",
+                    ],
+                    className="text-warning",
+                )
+
+            mismatch = current_mode and current_mode != detected_mode
+            icon_class = (
+                "bi bi-exclamation-triangle-fill me-1"
+                if mismatch
+                else "bi bi-check-circle me-1"
+            )
+            text_class = "text-warning" if mismatch else "text-success"
+            tail = (
+                f" Current selection ({current_mode}) does not match; "
+                f"consider switching to {detected_mode}."
+                if mismatch
+                else ""
+            )
+            return html.Small(
+                [
+                    html.I(className=icon_class),
+                    f"Detected layout: {layout_label} with {count_label} -> "
+                    f"suggested mode: {detected_mode}.{tail}",
+                ],
+                className=text_class,
+            )
+        except (OSError, ValueError) as exc:
+            logging.debug(f"Auto-detect preview failed for {path}: {exc}")
+            return ""
+
+    @app.callback(
         [
             Output("kraken-db-status", "children"),
             Output("kraken-db-feedback", "children")

--- a/nanometa_live/app/tabs/watchlist_tab.py
+++ b/nanometa_live/app/tabs/watchlist_tab.py
@@ -525,6 +525,53 @@ def register_watchlist_callbacks(app: Dash) -> None:
             except Exception as e:
                 logger.debug(f"Could not load mapping collection: {e}")
 
+        # Empty-state guard: if the taxonomy index has not been built
+        # (taxmap-collection store empty AND the global collection has no
+        # entries either), every row would otherwise render as
+        # "Not Found" -- which misleads the operator into thinking the
+        # species are absent from the database rather than the index
+        # being absent. Render a single empty-state card pointing at
+        # the Preparation tab control instead.
+        index_appears_empty = not mapping_dict
+        if index_appears_empty:
+            empty_state = dbc.Card(
+                dbc.CardBody(
+                    [
+                        html.Div(
+                            [
+                                html.I(
+                                    className="bi bi-database-exclamation me-2",
+                                    style={"fontSize": "1.5rem"},
+                                ),
+                                html.Strong("Taxonomy index is empty or stale."),
+                            ],
+                            className="mb-2",
+                        ),
+                        html.P(
+                            [
+                                "The watchlist cannot be checked against the "
+                                "Kraken2 database until the taxonomy index "
+                                "has been built. Open the ",
+                                html.Strong("Preparation"),
+                                " tab and click ",
+                                html.Strong("Scan Database"),
+                                " in the 'Verify Watchlist Against Database' "
+                                "card to (re)build the index.",
+                            ],
+                            className="mb-0 text-muted small",
+                        ),
+                    ]
+                ),
+                color="warning",
+                outline=True,
+                className="mb-3",
+            )
+            return (
+                [empty_state],
+                str(len(entries)),
+                {"display": "inline-block"},
+            )
+
         # Get genome status for all entries
         try:
             from nanometa_live.core.utils.genome_manager import get_genome_manager
@@ -562,16 +609,10 @@ def register_watchlist_callbacks(app: Dash) -> None:
             except Exception as e:
                 logger.error(f"Failed to create row for taxid {taxid} ({entry.get('name', 'Unknown')}): {e}")
 
-        # Add guidance note when no mapping data is available
-        if not mapping_dict:
-            rows.insert(0, html.Div(
-                html.Small([
-                    html.I(className="bi bi-info-circle me-1"),
-                    "Run 'Rescan DB' in the Preparation tab to check database compatibility",
-                ], className="text-muted"),
-                className="mb-2",
-            ))
-
+        # The "no mapping data" guidance note that used to live here was
+        # superseded by the empty-state card above (returned early when
+        # mapping_dict is empty); reaching this point implies at least one
+        # mapped entry, so a 'click Rescan' hint would be confusing.
         count = len(entries)
         return (
             rows,

--- a/nanometa_live/core/utils/classification_loaders.py
+++ b/nanometa_live/core/utils/classification_loaders.py
@@ -909,3 +909,33 @@ def load_kraken_latest_batch(main_dir: str, sample_name: str) -> pd.DataFrame:
         "No latest-batch report found for sample %s in %s", sample_name, kraken_dir
     )
     return pd.DataFrame(columns=KRAKEN2_EXPECTED_COLUMNS)
+
+
+def describe_kraken_scan_locations(main_dir: str) -> Dict[str, object]:
+    """Return a structured description of where the Kraken2 loader looks.
+
+    Used by the Analyze-error toast to tell the operator the absolute
+    path the loader scanned and the glob patterns it tried, so a
+    'Kraken2 reports not found' message can be diagnosed without
+    reading the source. The patterns mirror the priority order in
+    ``_parse_kraken_data_uncached``.
+
+    Returns a dict with keys:
+      - ``kraken_dir``: absolute path scanned (or expected, if absent).
+      - ``exists``: True iff ``kraken_dir`` is a directory on disk.
+      - ``patterns``: ordered list of glob patterns the loader tries.
+    """
+    resolved = resolve_analysis_directory(main_dir) if main_dir else ""
+    kraken_dir = (
+        os.path.abspath(os.path.join(resolved, "kraken2")) if resolved else ""
+    )
+    return {
+        "kraken_dir": kraken_dir,
+        "exists": bool(kraken_dir) and os.path.isdir(kraken_dir),
+        "patterns": [
+            "*.cumulative.kraken2.report.txt",
+            "*.kraken2.report.txt",
+            "*.kreport2.txt",
+            "*.kreport2",
+        ],
+    }

--- a/tests/test_classification_loaders.py
+++ b/tests/test_classification_loaders.py
@@ -554,3 +554,40 @@ class TestEmptyKrakenDirDiagnostics:
         )
         msg = _diagnose_empty_kraken_dir(str(tmp_path / "does-not-exist"))
         assert "unreadable" in msg
+
+
+# ---------------------------------------------------------------------------
+# describe_kraken_scan_locations
+# ---------------------------------------------------------------------------
+
+
+class TestDescribeKrakenScanLocations:
+    """Documents the loader's scan path for the Analyze-error toast."""
+
+    def test_returns_absolute_path_and_pattern_list(self, tmp_path):
+        from nanometa_live.core.utils.classification_loaders import (
+            describe_kraken_scan_locations,
+        )
+        scan = describe_kraken_scan_locations(str(tmp_path))
+        assert os.path.isabs(scan["kraken_dir"])
+        assert scan["kraken_dir"].endswith("kraken2")
+        assert scan["exists"] is False
+        assert "*.cumulative.kraken2.report.txt" in scan["patterns"]
+        assert "*.kraken2.report.txt" in scan["patterns"]
+
+    def test_exists_flag_true_when_directory_present(self, tmp_path):
+        from nanometa_live.core.utils.classification_loaders import (
+            describe_kraken_scan_locations,
+        )
+        (tmp_path / "kraken2").mkdir()
+        scan = describe_kraken_scan_locations(str(tmp_path))
+        assert scan["exists"] is True
+
+    def test_empty_main_dir_returns_empty_path(self):
+        from nanometa_live.core.utils.classification_loaders import (
+            describe_kraken_scan_locations,
+        )
+        scan = describe_kraken_scan_locations("")
+        assert scan["kraken_dir"] == ""
+        assert scan["exists"] is False
+        assert isinstance(scan["patterns"], list)

--- a/tests/test_watchlist_empty_state.py
+++ b/tests/test_watchlist_empty_state.py
@@ -1,0 +1,84 @@
+"""
+Empty-state regression for the watchlist pathogens table.
+
+When the taxonomy index has not been built (taxmap-collection store
+empty AND the global mapping collection is empty), the table used to
+render every entry as "Not Found", misleading the operator into
+thinking the species were absent from the database. The fix turns
+that into a single empty-state card pointing at the Preparation tab's
+Scan Database control. This test pins that contract.
+"""
+from unittest.mock import patch
+
+from nanometa_live.app.tabs.watchlist_tab import register_watchlist_callbacks
+
+
+def _stub_app_recorder():
+    """Capture the function registered with @app.callback so we can call it."""
+    captured = {}
+
+    class StubApp:
+        def callback(self, *args, **kwargs):
+            def decorator(fn):
+                # update_pathogens_table is the first callback that takes
+                # taxmap-collection as an Input; capture it by name.
+                if fn.__name__ == "update_pathogens_table":
+                    captured["fn"] = fn
+                return fn
+            return decorator
+
+    return StubApp(), captured
+
+
+class _StubManager:
+    """Pretend to be a WatchlistManager with two enabled entries."""
+    _loaded = True
+
+    def load_config(self, _config):
+        self._loaded = True
+
+    def get_entries_with_toggle_state(self):
+        return [
+            {"taxid": 562, "name": "Escherichia coli", "enabled": True,
+             "threat_level": "moderate", "common_name": "E. coli"},
+            {"taxid": 1280, "name": "Staphylococcus aureus", "enabled": True,
+             "threat_level": "high", "common_name": "S. aureus"},
+        ]
+
+
+def test_empty_taxmap_collection_renders_empty_state_not_not_found():
+    app, captured = _stub_app_recorder()
+    register_watchlist_callbacks(app)
+    fn = captured.get("fn")
+    assert fn is not None, "update_pathogens_table not registered"
+
+    with patch(
+        "nanometa_live.app.tabs.watchlist_tab.get_watchlist_manager",
+        return_value=_StubManager(),
+    ), patch(
+        "nanometa_live.core.taxonomy.taxid_mapping.get_mapping_collection",
+        return_value=None,
+    ):
+        rows, count, badge_style = fn(
+            tab_state={},
+            table_refresh=0,
+            search_term="",
+            rescan_complete=None,
+            taxmap_collection={},  # empty store
+            config={},
+        )
+
+    # The count badge still reflects the watchlist size...
+    assert count == "2"
+    assert badge_style == {"display": "inline-block"}
+    # ...but a single empty-state card stands in for the rows.
+    assert len(rows) == 1, "exactly one empty-state node, not N 'Not Found' rows"
+
+    # The empty-state copy should name the Preparation tab and the Scan
+    # Database control so the operator knows where to act.
+    rendered = str(rows[0])
+    assert "Taxonomy index" in rendered
+    assert "Preparation" in rendered
+    assert "Scan Database" in rendered
+    # And must not render the legacy "Not Found" text per row.
+    assert "Not Found" not in rendered


### PR DESCRIPTION
## Summary
Addresses three operator-facing UX gaps surfaced by the 2026-05-08 beta evaluation (Agent C of the four-agent eval plan).

- **Sample-handling picker copy + auto-detect preview.** Reworded radio labels so each option names the layout it fits (`single_sample - one merged sample (flat folder, e.g. nanorunner singleplex)`, `per_file - each file is its own sample (flat folder)`, `by_barcode - multiplexed (barcode01/, barcode02/, ...)`). New live-preview line under the radio reads the Nanopore Sequence Data Folder via `core.utils.auto_detect` and prints `Detected layout: <flat|barcoded|subdirectory-per-sample> with N FASTQ files -> suggested mode: <mode>`. Flags mismatches between the suggestion and the current selection without overwriting it.
- **Watchlist empty-state.** When the taxonomy index has not been built (taxmap-collection store empty AND no global mapping collection), the table used to render every entry as "Not Found", which misled the operator into believing the species were missing from the database. The empty branch now renders a single warning card pointing at the Preparation tab's "Scan Database" control.
- **Analyze-error toast names the loader scan path.** A new `emit_analyze_error_toast` callback watches `backend-status` and on transition into the error state surfaces a toast that includes the absolute path scanned (`<results>/kraken2/`) and the glob patterns the loader tries, sourced from a new `describe_kraken_scan_locations` helper in `core/utils/classification_loaders.py`.

## Test plan
- [x] `pytest tests/ -q` -> 868 passed, 1 skipped (baseline 864/1; +3 tests for the new helper, +1 pinning the watchlist empty-state contract).
- [x] App boot smoke test on port 8051: HTTP 200, no console errors.
- [x] Playwright check: typing `/tmp/nanorunner-fixture/flat` (4 pass_*.fastq) into the Nanopore Sequence Data Folder triggers `Detected layout: flat with 4 FASTQ files -> suggested mode: single_sample.`; typing `/tmp/nanorunner-fixture/multiplex` (3 barcode dirs) yields `Detected layout: barcoded with 3 sample folders -> suggested mode: by_barcode.`
- [ ] Manual: confirm the watchlist empty-state card is rendered when a built-in watchlist is loaded against a fresh `~/.nanometa` (covered indirectly by the new unit test).
- [ ] Manual: confirm the Analyze-error toast appears when a configured run fails with the known empty-`kraken2/` path.

Generated as Agent C in plan `make-a-evaluation-plan-async-yeti.md`.