### PR TITLE
eval/loader-empty-diagnostics: diagnose empty kraken2 result with directory contents and patterns

### DIFF
--- a/nanometa_live/core/utils/classification_loaders.py
+++ b/nanometa_live/core/utils/classification_loaders.py
@@ -35,6 +35,36 @@ KRAKEN2_EXPECTED_COLUMNS = ["%", "cumul_reads", "reads", "rank", "taxid", "name"
 KRAKEN2_EXPECTED_COLUMN_COUNT = 6
 
 
+def _diagnose_empty_kraken_dir(kraken_dir: str, sample: Optional[str] = None) -> str:
+    """
+    Build a single-line diagnostic for the case where the loader returns no
+    Kraken2 reports. Lists the directory's actual contents (capped) and the
+    glob patterns the loader tried, so an operator can triage from the log
+    without re-running the pipeline.
+    """
+    try:
+        entries = sorted(os.listdir(kraken_dir))
+    except OSError as exc:
+        return f"kraken_dir={kraken_dir!r} unreadable: {exc}"
+    files = [e for e in entries if os.path.isfile(os.path.join(kraken_dir, e))]
+    subdirs = [e for e in entries if os.path.isdir(os.path.join(kraken_dir, e))]
+    sample_hint = f" for sample={sample!r}" if sample else ""
+    patterns = [
+        "*.cumulative.kraken2.report.txt",
+        "*.kraken2.report.txt",
+        "*.kreport2.txt",
+        "*_batch*.kraken2.report.txt",
+    ]
+    return (
+        f"No Kraken2 reports{sample_hint} in {kraken_dir}. "
+        f"Patterns tried: {patterns}. "
+        f"Filename filters dropped any name containing '_batch', '.batch_', "
+        f"'.cumulative.' (when looking for non-cumulative reports). "
+        f"Files present ({len(files)}): {files[:10]}{'...' if len(files) > 10 else ''}. "
+        f"Subdirs ({len(subdirs)}): {subdirs[:10]}{'...' if len(subdirs) > 10 else ''}."
+    )
+
+
 def _scan_subdirs_for_pattern(
     parent_dir: str,
     file_pattern: str,
@@ -545,7 +575,7 @@ def _parse_kraken_data_uncached(
                         )
 
         if not kreport_files:
-            logging.warning("No Kraken2 report files found")
+            logging.warning(_diagnose_empty_kraken_dir(kraken_dir))
             return pd.DataFrame(columns=KRAKEN2_EXPECTED_COLUMNS)
 
         # Deduplicate by (sample, batch) so that copies of the same report
@@ -725,7 +755,7 @@ def _parse_kraken_data_uncached(
                         sample_files = [max(candidate_batches, key=_extract_batch_num)]
 
         if not sample_files:
-            logging.warning(f"No Kraken2 files found for sample {sample}")
+            logging.warning(_diagnose_empty_kraken_dir(kraken_dir, sample=sample))
             return pd.DataFrame(columns=KRAKEN2_EXPECTED_COLUMNS)
 
         # Parse files, using single-file fast path when possible

--- a/tests/test_classification_loaders.py
+++ b/tests/test_classification_loaders.py
@@ -523,3 +523,34 @@ class TestLoadKrakenDataFlatLayout:
         df = load_kraken_data(str(tmp_path), sample="legacy_sample")
         assert df is not None and not df.empty
         assert int(df.iloc[0]["reads"]) == 7
+class TestEmptyKrakenDirDiagnostics:
+    """When the loader returns empty, the warning must list directory state."""
+
+    def test_all_samples_empty_warning_lists_contents(self, tmp_path, caplog):
+        from nanometa_live.core.utils import classification_loaders as cl
+        kraken = tmp_path / "kraken2"
+        kraken.mkdir()
+        with caplog.at_level("WARNING", logger=""):
+            df = cl.load_kraken_data(str(tmp_path))
+        assert df.empty
+        msg = " ".join(rec.message for rec in caplog.records)
+        assert "No Kraken2 reports" in msg
+        assert "Patterns tried" in msg
+        assert "Files present (0)" in msg
+
+    def test_per_sample_empty_warning_names_sample(self, tmp_path, caplog):
+        from nanometa_live.core.utils import classification_loaders as cl
+        (tmp_path / "kraken2").mkdir()
+        with caplog.at_level("WARNING", logger=""):
+            df = cl.load_kraken_data(str(tmp_path), sample="ghost")
+        assert df.empty
+        msg = " ".join(rec.message for rec in caplog.records)
+        assert "sample='ghost'" in msg
+        assert "Patterns tried" in msg
+
+    def test_diagnostic_helper_handles_unreadable_dir(self, tmp_path):
+        from nanometa_live.core.utils.classification_loaders import (
+            _diagnose_empty_kraken_dir,
+        )
+        msg = _diagnose_empty_kraken_dir(str(tmp_path / "does-not-exist"))
+        assert "unreadable" in msg


### PR DESCRIPTION
## Summary

When `load_kraken_data` returns an empty DataFrame, the previous warning
(`No Kraken2 report files found`) gave the operator no actionable
information. This PR replaces both empty-return warning sites with a
single-line diagnostic that lists:

- the directory contents (capped at 10 files / 10 subdirs)
- the glob patterns the loader tried
- the basename filters that were applied (`_batch`, `.batch_`, `.cumulative.`)

Pairs with PR #74 (`eval/gui-mode-signposting`), where the Analyze-stage
error toast surfaces this string to the operator, so future "kraken2
reports not found" reports are self-diagnosing without a re-run.

## Context

Surfaced during the beta-tester evaluation (plan: `~/.claude/plans/make-a-evaluation-plan-async-yeti.md`).
The tester reported "Analyze phase error: kraken2 reports not found" but
follow-up testing on real `per_file` and `single_sample` outputs showed
the loader works correctly on flat layouts. The original warning was
silent enough that the upstream cause could not be confirmed from logs.

## Test plan

- [x] `pytest tests/` -> 867 passed, 1 skipped (864 baseline + 3 new)
- [x] `tests/test_classification_loaders.py::TestEmptyKrakenDirDiagnostics` -> 3/3