### PR TITLE
perf(loaders+viz): cut per-poll dashboard work from ~2 s to ~60 ms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,52 @@ which returns `(classified_reads, unclassified_reads, rate)` from
 the per-rank assignment column collapses to 0 when every read is parked at
 root level (the degenerate single-read input case caught by the audit).
 
+**Loader hot-path invariants (do not regress).** The Kraken2 loaders run on
+every poll, so per-element pandas access is the dominant cost on a large
+report. The 2026-06-05 perf pass (cProfile, 6 samples × ~3100 taxa) took the
+per-poll loader work from ~2 s to <0.1 s; keep these contracts:
+
+- **No per-row `df.iloc[idx][col]` in a parse loop.** `_parse_kraken2_report`
+  builds `parent_taxid` by iterating `df["name"].tolist()` / `df["taxid"].tolist()`,
+  not `df.iloc`. Each `df.iloc[idx]` materialises a cross-section Series
+  (`fast_xs`); on 3000 rows that alone was ~98% of loader time.
+- **Use `.tolist()`, not `.values`, for string columns in row loops.** Under
+  pandas 3.0 `.values` on the arrow-backed `name`/`rank` columns returns an
+  ExtensionArray whose per-element `[i]` goes through arrow `__getitem__`.
+  `_accumulate_kraken_df` extracts every column with `.tolist()` for this
+  reason. Numeric columns are unaffected but use `.tolist()` there too for
+  consistency.
+- **Single-report path skips accumulation.** `_parse_kraken_data_uncached`
+  (per-sample branch) parses into `parsed_frames` and returns the lone frame
+  directly when only one report contributes; `_accumulate_kraken_df` /
+  `_aggregate_to_result_df` run only for genuine multi-file aggregation.
+- **`get_sample_statistics_summary` parses each sample once when it safely can.**
+  `latest_batch_equals_cumulative(main_dir, sample)` (glob/stat only, no parse)
+  returns True only when the sample has neither a cumulative report nor any
+  per-batch report — the case where `load_kraken_data` and
+  `load_kraken_latest_batch` resolve to the same standard
+  `<sample>.kraken2.report.txt`. The summary reuses `cumul_df` then; otherwise
+  it loads the latest-batch horizon independently (the horizons legitimately
+  differ once a cumulative or batch report exists). Regression-covered in
+  `tests/test_qc_loaders_horizon.py`.
+
+All four were behaviour-preserving (loader output is byte-identical, verified
+by sha256 over the full frame incl. `parent_taxid`).
+
+**Sunburst node cap (visualization invariant).** `create_sunburst_data`
+(`app/tabs/classification_helpers.py`) takes `max_taxa_per_level` and keeps the
+top-N taxa by recalculated cumulative reads at each rank, mirroring
+`create_sankey_data`. The classification callback passes the same `max_taxa`
+value to both views, so they stay consistent. The default is `0` (= no cap) so
+existing callers and tests are unchanged; the callback's own default is the
+shared `max_taxa` (10, with 0 mapped to "no limit"). The cap is not only a
+readability control: ~60% of an uncapped sunburst build is plotly's
+per-element trace validation, which scales with node count (~3100 species nodes
+on a GTDB run took ~57 ms; capped ~15 ms). A node whose direct parent is capped
+out reparents to its nearest still-present ancestor (or `root`) via
+`_resolve_sunburst_parent`, so capping never orphans a node. Regression-covered
+in `tests/test_sunburst_tax_levels.py`.
+
 ### PAF Files (minimap2 validation)
 
 ```

--- a/nanometa_live/app/tabs/classification_helpers.py
+++ b/nanometa_live/app/tabs/classification_helpers.py
@@ -818,20 +818,32 @@ def _resolve_sunburst_parent(node_taxid, taxon_name_full, row_idx, level_idx,
 
 
 def _build_sunburst_nodes(filtered_df, tax_levels, total_reads, palette,
-                          use_taxid_parents, taxid_to_parent, taxid_to_key):
+                          use_taxid_parents, taxid_to_parent, taxid_to_key,
+                          max_taxa_per_level=0):
     """Build the sunburst node arrays under a synthetic ``root``.
 
     Returns ``(ids, labels, parents, values, colors, custom_data)``. Each
     node's parent is the nearest ancestor already added, keeping the hierarchy
     connected; colour varies by within-level position.
+
+    ``max_taxa_per_level`` (when > 0) keeps only the top-N taxa by recalculated
+    cumulative reads at each rank, mirroring the Sankey builder. This bounds the
+    node count handed to plotly -- whose per-element trace validation dominates
+    sunburst build time -- and keeps a dense chart readable. A node whose direct
+    parent was capped out reparents to its nearest still-present ancestor (or
+    root) via ``_resolve_sunburst_parent``, so capping never orphans a node.
     """
     ids, labels, parents, values, colors, custom_data = [], [], [], [], [], []
+    cap = max_taxa_per_level if max_taxa_per_level and max_taxa_per_level > 0 else None
 
-    # First pass: count items per level (for colour variation).
+    # First pass: count items per level (for colour variation). The count is
+    # bounded by the cap so the within-level brightness spread matches the
+    # number of nodes actually rendered.
     level_counts = {}
     level_positions = {}
     for level in tax_levels:
-        level_counts[level] = len(filtered_df[filtered_df["rank"] == level])
+        n_level = len(filtered_df[filtered_df["rank"] == level])
+        level_counts[level] = min(n_level, cap) if cap else n_level
         level_positions[level] = 0
 
     first_level = tax_levels[0] if tax_levels else "D"
@@ -852,6 +864,8 @@ def _build_sunburst_nodes(filtered_df, tax_levels, total_reads, palette,
         level_df = filtered_df[filtered_df["rank"] == level].sort_values(
             "recalc_cumul", ascending=False
         )
+        if cap:
+            level_df = level_df.head(cap)
         logging.debug(f"Sunburst: Processing level {level} with {len(level_df)} items")
 
         # Pre-extract columns to avoid iterrows overhead.
@@ -889,7 +903,8 @@ def _build_sunburst_nodes(filtered_df, tax_levels, total_reads, palette,
     return ids, labels, parents, values, colors, custom_data
 
 
-def create_sunburst_data(kraken_df, domains, tax_levels, min_reads, config, color_palette=None):
+def create_sunburst_data(kraken_df, domains, tax_levels, min_reads, config,
+                         color_palette=None, max_taxa_per_level=0):
     """
     Create a modern, well-styled Sunburst chart from Kraken report.
 
@@ -907,6 +922,9 @@ def create_sunburst_data(kraken_df, domains, tax_levels, min_reads, config, colo
         min_reads: Minimum reads for inclusion
         config: Application configuration
         color_palette: Dictionary mapping taxonomy ranks to colors (optional)
+        max_taxa_per_level: Keep only the top-N taxa by reads at each rank
+            (0 = no cap). Mirrors create_sankey_data; bounds the plotly node
+            count so a dense report stays both fast to render and readable.
 
     Returns:
         A go.Figure with the styled Sunburst chart
@@ -983,6 +1001,7 @@ def create_sunburst_data(kraken_df, domains, tax_levels, min_reads, config, colo
     ids, labels, parents, values, colors, custom_data = _build_sunburst_nodes(
         filtered_df, tax_levels, total_reads, palette,
         use_taxid_parents, taxid_to_parent, taxid_to_key,
+        max_taxa_per_level=max_taxa_per_level,
     )
 
     # Detect orphan parents (referenced but never added).

--- a/nanometa_live/app/tabs/classification_tab.py
+++ b/nanometa_live/app/tabs/classification_tab.py
@@ -248,7 +248,7 @@ def register_classification_callbacks(app: Dash):
 
             # Generate visualization based on type
             if view_type == "sunburst":
-                figure = create_sunburst_data(kraken_df, domains, tax_levels, filter_value, config, color_palette)
+                figure = create_sunburst_data(kraken_df, domains, tax_levels, filter_value, config, color_palette, max_taxa_per_level=max_taxa)
                 if figure is None:
                     return create_empty_sunburst("No data matches the selected filters"), None, graph_visible
                 return figure, None, graph_visible

--- a/nanometa_live/core/utils/classification_loaders.py
+++ b/nanometa_live/core/utils/classification_loaders.py
@@ -186,14 +186,24 @@ def _parse_kraken2_report(filepath: str, check_stability: bool = True) -> Option
         # but preserve leading spaces for hierarchy visualization
         df["name"] = df["name"].fillna("unknown")
 
-        # Build parent_taxid from indentation-based hierarchy
-        # Uses a stack to track the parent at each indentation depth
+        # Build parent_taxid from indentation-based hierarchy.
+        # Uses a stack to track the parent at each indentation depth.
+        #
+        # The two columns are extracted to plain Python lists ONCE before the
+        # loop. The previous per-row ``df.iloc[idx][col]`` access dominated the
+        # entire loader: each call materialises a cross-section Series (pandas
+        # fast_xs), so a 3000-row report cost ~110 ms and an all-samples load
+        # ~660 ms, essentially all of it here (cProfile, 2026-06-05). Iterating
+        # over pre-extracted lists leaves the indent-stack algorithm identical
+        # while removing the cross-section overhead.
+        names = df["name"].tolist()
+        taxid_values = df["taxid"].tolist()
         parent_taxids = []
         indent_stack = []  # list of (indent_level, taxid) tuples
-        for idx in range(len(df)):
-            name_val = df.iloc[idx]["name"]
-            indent = len(name_val) - len(str(name_val).lstrip())
-            taxid = int(df.iloc[idx]["taxid"])
+        for name_val, taxid_val in zip(names, taxid_values):
+            name_str = str(name_val)
+            indent = len(name_str) - len(name_str.lstrip())
+            taxid = int(taxid_val)
 
             # Pop stack entries with indent >= current (siblings or deeper)
             while indent_stack and indent_stack[-1][0] >= indent:

--- a/nanometa_live/core/utils/classification_loaders.py
+++ b/nanometa_live/core/utils/classification_loaders.py
@@ -881,6 +881,46 @@ def load_kraken_latest_batch(main_dir: str, sample_name: str) -> pd.DataFrame:
     return pd.DataFrame(columns=KRAKEN2_EXPECTED_COLUMNS)
 
 
+def latest_batch_equals_cumulative(main_dir: str, sample_name: str) -> bool:
+    """True when a sample's latest-batch horizon is identical to its cumulative.
+
+    This holds only when the sample has **neither** per-batch reports **nor** a
+    cumulative report: in that case both ``load_kraken_data`` (step 2 of
+    ``_discover_sample_reports``) and ``load_kraken_latest_batch`` (its standard
+    fallback) resolve to the very same ``<sample>.kraken2.report.txt``, so they
+    return identical data. A caller that needs both horizons can then reuse the
+    cumulative frame instead of parsing the same file twice -- the common
+    batch-mode case in ``get_sample_statistics_summary``.
+
+    Returns ``False`` whenever a cumulative report or any batch report exists,
+    because then the two horizons can legitimately differ and must be loaded
+    independently. The check is glob/stat-only (no parsing), so it is far
+    cheaper than the redundant parse it guards.
+    """
+    main_dir = resolve_analysis_directory(main_dir)
+    kraken_dir = os.path.join(main_dir, "kraken2")
+
+    # A cumulative report means load_kraken_data used it (not the standard
+    # report), so the latest-batch fallback is not guaranteed to match.
+    for cumul in (
+        os.path.join(kraken_dir, f"{sample_name}.cumulative.kraken2.report.txt"),
+        os.path.join(kraken_dir, sample_name, f"{sample_name}.cumulative.kraken2.report.txt"),
+    ):
+        if os.path.exists(cumul):
+            return False
+
+    # Any per-batch report means a distinct latest-batch horizon exists.
+    if glob.glob(os.path.join(kraken_dir, f"{sample_name}_batch*.kraken2.report.txt")):
+        return False
+    batch_dir = os.path.join(kraken_dir, sample_name, "batch_reports")
+    if os.path.isdir(batch_dir) and glob.glob(
+        os.path.join(batch_dir, "*.kraken2.report.txt")
+    ):
+        return False
+
+    return True
+
+
 def describe_kraken_scan_locations(main_dir: str) -> Dict[str, object]:
     """Return a structured description of where the Kraken2 loader looks.
 

--- a/nanometa_live/core/utils/classification_loaders.py
+++ b/nanometa_live/core/utils/classification_loaders.py
@@ -460,16 +460,26 @@ def _accumulate_kraken_df(
     Reads and cumulative reads are summed per taxid; the remaining
     columns (rank, name, parent_taxid) are taken from the first
     occurrence. New taxids are appended to ``ordered_taxids`` in
-    first-seen order. Vectorized extraction avoids per-row overhead.
+    first-seen order.
+
+    Columns are extracted to plain Python lists via ``.tolist()`` rather
+    than ``.values``: under pandas 3.0 ``.values`` on the arrow-backed
+    string columns (``rank``, ``name``) returns an ExtensionArray whose
+    per-element ``[i]`` access goes through arrow ``__getitem__`` and
+    dominated this loop (cProfile, 2026-06-05). ``.tolist()`` materialises
+    native Python scalars once so the loop body is plain list indexing.
     """
-    taxids = df['taxid'].astype(int).values
-    reads_arr = df['reads'].values
-    cumul_arr = df['cumul_reads'].values
-    ranks = df['rank'].values
-    names = df['name'].values
-    parent_taxids_arr = df['parent_taxid'].values if 'parent_taxid' in df.columns else [0] * len(df)
-    for i in range(len(df)):
-        taxid = int(taxids[i])
+    n = len(df)
+    taxids = df['taxid'].astype(int).tolist()
+    reads_arr = df['reads'].tolist()
+    cumul_arr = df['cumul_reads'].tolist()
+    ranks = df['rank'].tolist()
+    names = df['name'].tolist()
+    parent_taxids_arr = (
+        df['parent_taxid'].tolist() if 'parent_taxid' in df.columns else [0] * n
+    )
+    for i in range(n):
+        taxid = taxids[i]
         if taxid in agg:
             agg[taxid][0] += reads_arr[i]
             agg[taxid][1] += cumul_arr[i]
@@ -759,26 +769,31 @@ def _parse_kraken_data_uncached(
         logging.log(level, _diagnose_empty_kraken_dir(kraken_dir, sample=sample))
         return pd.DataFrame(columns=KRAKEN2_EXPECTED_COLUMNS)
 
-    # Parse files, using a single-file fast path when possible.
-    first_df = None
-    file_count = 0
-    agg = {}
-    ordered_taxids = []
-    seen_taxids = set()
+    # Parse files first; defer the per-taxid accumulation until we know more
+    # than one report actually contributed. The single-report case -- the
+    # common one for a per-sample cumulative report -- returns the parsed
+    # frame directly and skips the accumulation pass entirely. The previous
+    # code accumulated the first frame unconditionally and then discarded the
+    # result when file_count == 1, an O(rows) pass wasted on every single-file
+    # load (cProfile, 2026-06-05).
+    parsed_frames: List[pd.DataFrame] = []
     for sample_file in sample_files:
         df = _parse_kraken2_report(sample_file)
         if df is None or df.empty:
             continue
-        file_count += 1
-        if file_count == 1:
-            first_df = df
-        _accumulate_kraken_df(df, agg, ordered_taxids, seen_taxids)
+        parsed_frames.append(df)
 
-    if file_count == 0:
+    if not parsed_frames:
         return pd.DataFrame(columns=KRAKEN2_EXPECTED_COLUMNS)
-    if file_count == 1:
+    if len(parsed_frames) == 1:
         # Single file: return its DataFrame directly (no aggregation needed).
-        return _cache_and_return(first_df, cache_key, mtime_key, kraken_dir)
+        return _cache_and_return(parsed_frames[0], cache_key, mtime_key, kraken_dir)
+
+    agg: Dict[int, List] = {}
+    ordered_taxids: List[int] = []
+    seen_taxids: set = set()
+    for df in parsed_frames:
+        _accumulate_kraken_df(df, agg, ordered_taxids, seen_taxids)
     result_df = _aggregate_to_result_df(agg, ordered_taxids)
     return _cache_and_return(result_df, cache_key, mtime_key, kraken_dir)
 

--- a/nanometa_live/core/utils/qc_loaders.py
+++ b/nanometa_live/core/utils/qc_loaders.py
@@ -879,6 +879,7 @@ def get_sample_statistics_summary(main_dir: str) -> pd.DataFrame:
     from nanometa_live.core.utils.classification_loaders import (
         load_kraken_data,
         load_kraken_latest_batch,
+        latest_batch_equals_cumulative,
     )
 
     # Auto-resolve to analysis directory if needed
@@ -947,7 +948,14 @@ def get_sample_statistics_summary(main_dir: str) -> pd.DataFrame:
             total_reads = kraken_total_cumul
 
         # --- Latest-batch horizon ---
-        latest_df = load_kraken_latest_batch(main_dir, sample)
+        # When the sample has no batch reports and no cumulative report, the
+        # latest-batch horizon is byte-identical to the cumulative one (both
+        # resolve to the same standard <sample>.kraken2.report.txt). Reuse the
+        # already-parsed cumul_df instead of parsing the same file again.
+        if latest_batch_equals_cumulative(main_dir, sample):
+            latest_df = cumul_df
+        else:
+            latest_df = load_kraken_latest_batch(main_dir, sample)
         classified_latest, unclassified_latest, kraken_total_latest = (
             _kraken_classification_counts(latest_df)
         )

--- a/tests/test_qc_loaders_horizon.py
+++ b/tests/test_qc_loaders_horizon.py
@@ -150,3 +150,63 @@ class TestSampleSummaryHorizons:
         assert row["classified_rate_cumul_num"] == 90.0
         assert row["classified_rate_latest_num"] == 20.0
         assert "Complete" in row["status"]
+
+
+class TestLatestBatchEqualsCumulative:
+    """The dedup guard that lets the summary skip a redundant parse."""
+
+    def test_true_for_standard_report_only(self, tmp_path):
+        """A lone standard report (no cumulative, no batch) -> horizons equal."""
+        from nanometa_live.core.utils.classification_loaders import (
+            latest_batch_equals_cumulative,
+        )
+        kraken_dir = tmp_path / "kraken2"
+        _write_kraken_report(
+            kraken_dir / "barcode01.kraken2.report.txt",
+            classified=150, unclassified=50,
+        )
+        assert latest_batch_equals_cumulative(str(tmp_path), "barcode01") is True
+
+    def test_false_when_cumulative_present(self, tmp_path):
+        from nanometa_live.core.utils.classification_loaders import (
+            latest_batch_equals_cumulative,
+        )
+        kraken_dir = tmp_path / "kraken2"
+        _write_kraken_report(
+            kraken_dir / "barcode01.kraken2.report.txt", classified=150, unclassified=50,
+        )
+        _write_kraken_report(
+            kraken_dir / "barcode01.cumulative.kraken2.report.txt",
+            classified=150, unclassified=50,
+        )
+        assert latest_batch_equals_cumulative(str(tmp_path), "barcode01") is False
+
+    def test_false_when_batch_present(self, tmp_path):
+        from nanometa_live.core.utils.classification_loaders import (
+            latest_batch_equals_cumulative,
+        )
+        kraken_dir = tmp_path / "kraken2"
+        _write_kraken_report(
+            kraken_dir / "barcode01.kraken2.report.txt", classified=150, unclassified=50,
+        )
+        _write_kraken_report(
+            kraken_dir / "barcode01_batch0.kraken2.report.txt",
+            classified=150, unclassified=50,
+        )
+        assert latest_batch_equals_cumulative(str(tmp_path), "barcode01") is False
+
+    def test_summary_dedup_path_matches_horizons(self, tmp_path):
+        """With only a standard report, the dedup reuses cumul_df and the
+        latest horizon equals the cumulative one (no separate parse)."""
+        kraken_dir = tmp_path / "kraken2"
+        _write_empty_fastp(tmp_path / "fastp", "barcode01")
+        _write_kraken_report(
+            kraken_dir / "barcode01.kraken2.report.txt",
+            classified=300, unclassified=100,
+        )
+        df = get_sample_statistics_summary(str(tmp_path))
+        row = df.iloc[0]
+        assert row["reads_cumul"] == 400
+        assert row["reads_latest"] == 400
+        assert row["classified_cumul"] == row["classified_latest"] == 300
+        assert row["classified_rate_latest_num"] == row["classified_rate_cumul_num"]

--- a/tests/test_sunburst_tax_levels.py
+++ b/tests/test_sunburst_tax_levels.py
@@ -247,5 +247,65 @@ class TestSunburstEdgeCases:
         assert elapsed < 3.0, f"Should complete within 3s, took {elapsed:.2f}s"
 
 
+class TestSunburstMaxTaxaPerLevel:
+    """Test the max_taxa_per_level cap on Sunburst node count."""
+
+    @staticmethod
+    def _nodes(fig):
+        tr = fig.data[0]
+        return list(tr.ids), list(tr.parents), list(tr.labels)
+
+    def test_cap_bounds_nodes_per_level(self, kraken_data_medium, sample_config):
+        """A cap keeps at most N taxa per rank and never orphans a node."""
+        levels = ["D", "P", "C", "O", "F", "G", "S"]
+        cap = 2
+        fig = create_sunburst_data(
+            kraken_data_medium, domains=["Bacteria"], tax_levels=levels,
+            min_reads=1, config=sample_config, max_taxa_per_level=cap,
+        )
+        ids, parents, _ = self._nodes(fig)
+
+        # No orphan parents: every referenced parent is a real node (or root "").
+        orphans = (set(parents) - {""}) - set(ids)
+        assert not orphans, f"capping orphaned parents: {orphans}"
+
+        # Per-rank node count is bounded by the cap. Node ids are "<rank>_<name>"
+        # (plus the synthetic "root").
+        per_rank = {}
+        for nid in ids:
+            if nid == "root":
+                continue
+            rank = nid.split("_", 1)[0]
+            per_rank[rank] = per_rank.get(rank, 0) + 1
+        for rank, count in per_rank.items():
+            assert count <= cap, f"rank {rank} has {count} nodes, cap was {cap}"
+
+    def test_cap_reduces_node_count(self, kraken_data_medium, sample_config):
+        """Capping yields strictly fewer nodes than the uncapped default."""
+        levels = ["D", "P", "C", "O", "F", "G", "S"]
+        uncapped = create_sunburst_data(
+            kraken_data_medium, domains=["Bacteria"], tax_levels=levels,
+            min_reads=1, config=sample_config,
+        )
+        capped = create_sunburst_data(
+            kraken_data_medium, domains=["Bacteria"], tax_levels=levels,
+            min_reads=1, config=sample_config, max_taxa_per_level=2,
+        )
+        assert len(self._nodes(capped)[0]) < len(self._nodes(uncapped)[0])
+
+    def test_default_is_uncapped(self, kraken_data_medium, sample_config):
+        """Omitting max_taxa_per_level preserves the pre-cap behavior (no cap)."""
+        levels = ["D", "P", "C", "O", "F", "G", "S"]
+        default = create_sunburst_data(
+            kraken_data_medium, domains=["Bacteria"], tax_levels=levels,
+            min_reads=1, config=sample_config,
+        )
+        explicit_zero = create_sunburst_data(
+            kraken_data_medium, domains=["Bacteria"], tax_levels=levels,
+            min_reads=1, config=sample_config, max_taxa_per_level=0,
+        )
+        assert len(self._nodes(default)[0]) == len(self._nodes(explicit_zero)[0])
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
## Summary

Profile-first performance pass on the Kraken2 loader and classification-tab
visualization hot paths. cProfile against a representative workload (6 barcoded
samples × ~3,100-taxa GTDB-style reports) found the per-poll cost was dominated
by pandas per-element access, not I/O. Four targeted, verified changes bring the
realistic per-poll work from **~2 s to ~50–75 ms**.

## Measured impact (6-sample × ~3,100-taxa run, cache cleared each iteration)

| Path | Original | Now | Speedup |
|---|---|---|---|
| `load_kraken_data(All Samples)` | 660 ms | 28 ms | ~24× |
| `get_sample_statistics_summary` | 1365 ms | 28 ms | ~49× |
| `create_sunburst_data` (default cap) | 57 ms | 15 ms | ~3.9× |
| `create_sankey_data` | 20 ms | 20 ms | already capped |
| fingerprint walk | 0.1 ms | 0.1 ms | already fine |

## Commits

1. **`91ed949` vectorize the Kraken2 parse indent loop** — `_parse_kraken2_report`
   built `parent_taxid` with two `df.iloc[idx][col]` scalar lookups per row
   (each materialises a cross-section Series via `fast_xs`; pandas 3.0
   arrow-backed strings make it worse). Extract the two columns to lists once,
   then iterate. cProfile attributed 98% of loader time here.
2. **`8699fe5` skip the discarded accumulation pass + `.tolist()`** — the
   per-sample single-report path accumulated the first frame, then threw the
   result away when only one report contributed; and `_accumulate_kraken_df`
   read string columns via `.values` (an Arrow ExtensionArray → slow per-element
   `__getitem__`). Defer accumulation until >1 frame contributes; use `.tolist()`.
3. **`10c7308` cap sunburst nodes per level** — ~60% of `create_sunburst_data`
   was plotly's per-element trace validation, scaling with the uncapped ~3,100
   node count. Add `max_taxa_per_level` (default 0 = no cap), threaded through
   `_build_sunburst_nodes`, keeping the top-N by reads per rank like the Sankey
   builder; the callback now passes the same `max_taxa` value both views use. A
   capped-out parent reparents to its nearest present ancestor (or root), so
   capping never orphans a node.
4. **`6d7fc66` skip the redundant latest-batch re-parse** —
   `get_sample_statistics_summary` parsed each sample twice (cumulative +
   latest-batch). New `latest_batch_equals_cumulative()` guard (glob/stat only,
   no parse) detects the batch-mode case where both resolve to the same standard
   report and reuses the already-parsed frame; the independent latest-batch load
   is kept untouched whenever a cumulative or batch report exists.

## Verification

- All loader changes produce **byte-identical output** (sha256 over the full
  frame incl. `parent_taxid`, all-samples and per-sample, and the
  `get_sample_statistics_summary` frame).
- The one behavior change (sunburst node cap) is deliberate — more readable
  *and* faster — and test-covered.
- **7 new regression tests** (sunburst cap truth table + node bounds; latest/
  cumulative dedup guard + horizon equality).
- Full suite: **2166 passed, 1 skipped** on Python 3.13 / pandas 3.0.2 /
  dash 4.1.0 (nf-core env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)