### PR TITLE
fix(gui): resolve local-server user-testing feedback (watchlist, config, text)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,14 @@ Full walkthrough: [`docs/developer-guide.md`](docs/developer-guide.md).
 **Background callback isolation:** Dash `DiskcacheManager` runs background callbacks
 in a separate OS process, so Python singletons (e.g. `WatchlistManager`) are empty there.
 Share state via a `dcc.Store` populated in a main-process callback and read via `State`.
+Concretely: any background callback that needs the watchlist MUST take
+`State("watchlist-entries-snapshot", "data")` and use it instead of
+`get_watchlist_manager()`. The readiness checker is one such case —
+`update_readiness_state` (`app/callbacks/readiness.py`) passes the snapshot into
+`ReadinessChecker.check_readiness(..., watchlist_entries=...)`; without it the
+worker's empty singleton makes every watchlist check report "not enabled". The
+snapshot carries `enabled` per entry (set in `hydrate_watchlist_entries_snapshot`)
+so the checks can filter to the active set.
 
 **Update cadence and session writes.** A single global
 `dcc.Interval(id='update-interval')` drives all polling, default 30 s
@@ -290,6 +298,20 @@ forget to Apply and launch with stale config. Form-loader `.get(key, default)`
 fallbacks must match `create_default_config` — a divergent default (e.g.
 `validation_method`, `sample_handling`) only surfaces when a key is absent, a
 latent trap since `load_config` merges defaults on read.
+
+**Form-draft autosave.** Switching tabs re-fires `refresh-form-trigger`
+(`trigger_initial_form_load` on `tabs.active_tab` change), so
+`initialize_form_from_config` re-runs and would discard unsaved edits. To keep
+edits across a tab switch, `detect_form_changes` also writes the in-progress
+`form` dict to the session Store `config-form-draft` (the dict it already
+builds for the dirty check — same `build_config_from_form` keys), and
+`initialize_form_from_config` overlays that draft on top of the saved config
+(`config = {**config, **draft}`). The draft is the *fourth* writer of the form
+state and must stay key-compatible with the other three lists above. It is
+cleared (`None`) on Load and Reset so those authoritative actions win; Apply
+needs no clear because the draft already equals the applied config. Edits are
+still only persisted to `last-session.yaml` on Apply — the draft is a
+session-scoped convenience, not a saved config.
 
 ## Watchlist System
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -202,7 +202,7 @@ pathogens:
 
 ### Creating Custom Watchlists
 
-Save a YAML file following the v2.0 format and import it through the Watchlist tab in the GUI. Example files are provided in `nanometa_live/core/config/data/watchlists/examples/`:
+Save a YAML file following the v2.0 format and import it through the Watchlist & Preparation tab in the GUI. Example files are provided in `nanometa_live/core/config/data/watchlists/examples/`:
 
 - `sti_pathogens.yaml` - Sexually transmitted infection organisms
 - `neglected_tropical_diseases.yaml` - NTD surveillance targets
@@ -210,7 +210,7 @@ Save a YAML file following the v2.0 format and import it through the Watchlist t
 
 ### Taxid Mapping
 
-When a watchlist is loaded, Nanometa Live maps each `taxid_ncbi` to the active Kraken2 database. Organisms not present in the database (e.g., eukaryotic parasites in a bacteria-only database) are reported as unmapped in the Preparation tab. Use a PlusPF or PlusPFP Kraken2 database for broader organism coverage.
+When a watchlist is loaded, Nanometa Live maps each `taxid_ncbi` to the active Kraken2 database. Organisms not present in the database (e.g., eukaryotic parasites in a bacteria-only database) are reported as unmapped in the Watchlist & Preparation tab. Use a PlusPF or PlusPFP Kraken2 database for broader organism coverage.
 
 ## Pipeline Source Options
 

--- a/docs/local-server-testing.md
+++ b/docs/local-server-testing.md
@@ -126,10 +126,10 @@ minimal config is shown in [Appendix A](#appendix-a-minimal-configyaml).
    - Leave "Results folder" empty so it derives `results/<run name>`.
    - Click **Apply Settings**. Expect a "Viewing: .../results/batch_run" line.
 
-2. **Watchlist tab** -- click a built-in list that covers the mock species
-   (e.g. **Clinical Pathogens**). Confirm the active count is non-zero.
+2. **Watchlist & Preparation tab** -- click a built-in list that covers the mock
+   species (e.g. **Clinical Pathogens**). Confirm the active count is non-zero.
 
-3. **Preparation tab** -- click **Start Preparation**. This builds the DB
+3. **Same tab (Prepare for Analysis section)** -- click **Start Preparation**. This builds the DB
    taxonomy index + taxid mappings, downloads the watched species' reference
    genomes, and builds validation indexes. Wait for "Preparation complete";
    the readiness badge should turn **Ready** and Start should enable.

--- a/docs/runbooks/manual-server-profile-scenarios.md
+++ b/docs/runbooks/manual-server-profile-scenarios.md
@@ -244,7 +244,7 @@ python -m nanometa_live.app \
 Open `http://localhost:8050/` and:
 
 1. **Configuration tab**: verify the loaded config matches `scenario_A.yaml`. The readiness badge should turn green within a few seconds (it now runs in the background, so it does not block the page).
-2. **Preparation tab**: click *Run Preparation*. Watch the genome-download and BLAST-build progress; both finish in a minute or two for a small watchlist. This step is required for validation but optional for the headline real-time path.
+2. **Watchlist & Preparation tab**: click *Run Preparation*. Watch the genome-download and BLAST-build progress; both finish in a minute or two for a small watchlist. This step is required for validation but optional for the headline real-time path.
 3. **Dashboard tab**: click *Start Pipeline*. The verdict banner flips immediately to "starting", then settles to "running" once the first Nextflow process spawns. Conda envs build on the first run (~10-30 min cold); subsequent runs reuse the cache.
 4. Once Kraken2 produces its first cumulative report (~60-120 s after the first FASTQ batch lands), the dashboard tile starts ticking, organisms appear in the Organisms tab, and the QC plots populate.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -136,9 +136,10 @@ Organism identity verification:
 - **Coverage Sub-tab**: Genome-centric minimap2 coverage plots (depth, cumulative, histogram)
 - Species selector and mapping quality filters
 
-### Watchlist tab
+### Watchlist & Preparation tab
 
-Pathogen monitoring management:
+Pathogen monitoring management (watchlist selection and pre-run preparation are
+combined in this single tab):
 - Browse and activate the 9 built-in watchlists (clinical_pathogens, cdc_bioterrorism, who_priority, foodborne, respiratory, who_drinking_water, nosocomial_eskape, wastewater_surveillance, zoonotic_one_health)
 - Upload custom watchlist YAML files
 - Toggle individual pathogen entries on/off
@@ -152,9 +153,9 @@ Analysis settings:
 - Processing mode (batch/real-time)
 - Start/stop analysis controls
 
-### Preparation tab
+### Preparation (part of the Watchlist & Preparation tab)
 
-Pre-run setup:
+Pre-run setup, in the lower section of the Watchlist & Preparation tab:
 - Reference genome downloads for watchlist pathogens
 - BLAST database preparation
 - Genome management status

--- a/docs/validation-walkthrough-checklist.md
+++ b/docs/validation-walkthrough-checklist.md
@@ -36,7 +36,7 @@
 | 10 | Alert banner - barcode04 | No alert banners | [ ] | |
 | 11 | Classification tab | Taxonomy breakdown visible, taxa match scenario | [ ] | |
 | 12 | QC tab | FASTP metrics per barcode: reads, quality, length | [ ] | |
-| 13 | Watchlist tab | Built-in watchlists load, toggle entries on/off | [ ] | |
+| 13 | Watchlist & Preparation tab | Built-in watchlists load, toggle entries on/off | [ ] | |
 | 14 | Validation tab | Results section renders | [ ] | |
 | 15 | View Coverage - barcode01 | 3 plots render (depth, cumulative, histogram) | [ ] | |
 | 16 | Config tab | Current config displays correctly | [ ] | |

--- a/nanometa_live/app/app.py
+++ b/nanometa_live/app/app.py
@@ -729,7 +729,7 @@ def create_app(
                                              "display": "inline-flex", "alignItems": "center", "justifyContent": "center"}),
                             html.Strong("Set up Watchlist"),
                         ], className="d-flex align-items-center mb-1"),
-                        html.P("Go to the Watchlist tab to select which organisms to monitor for alerts.",
+                        html.P("Go to the Watchlist & Preparation tab to select which organisms to monitor for alerts.",
                                className="text-muted small ms-4 mb-3"),
                     ]),
                     html.Div([
@@ -739,7 +739,7 @@ def create_app(
                                              "display": "inline-flex", "alignItems": "center", "justifyContent": "center"}),
                             html.Strong("Prepare Databases"),
                         ], className="d-flex align-items-center mb-1"),
-                        html.P("Go to the Preparation tab to download reference genomes and build validation databases.",
+                        html.P("Go to the Watchlist & Preparation tab to download reference genomes and build validation databases.",
                                className="text-muted small ms-4 mb-3"),
                     ]),
                     html.Div([

--- a/nanometa_live/app/callbacks/indicators.py
+++ b/nanometa_live/app/callbacks/indicators.py
@@ -29,6 +29,14 @@ from nanometa_live.app.app import background_callback_manager
 # notifications does not accumulate an unbounded list in the store.
 _MAX_NOTIFICATIONS = 10
 
+# Coalesce identical toasts fired in quick succession into one. A per-entry
+# loop (e.g. genome/taxid preparation iterating watchlist entries) can write
+# the same "Validated x/x" message to the store many times in a burst; without
+# this the operator gets a wall of duplicate pop-ups. Distinct messages are
+# unaffected. Process-local; the GUI runs the toast renderer in the main process.
+_TOAST_DEDUP_WINDOW_S = 5.0
+_toast_dedup: Dict[str, Any] = {"sig": None, "ts": 0.0}
+
 # The legacy notification-trigger channel labels severity with a Bootstrap
 # "color"; the toast channel uses "type". This maps the former onto the
 # latter so both feed the single unified toast renderer.
@@ -217,6 +225,17 @@ def register_indicators(app, backend_manager):
             )
             title = payload.get("title", "Notification")
             message = payload.get("message", "")
+
+            # Coalesce a burst of identical toasts (e.g. a per-entry prep loop
+            # writing the same "Validated x/x" message repeatedly) into one.
+            sig = (toast_type, title, message)
+            now = time.time()
+            if (sig == _toast_dedup["sig"]
+                    and (now - _toast_dedup["ts"]) < _TOAST_DEDUP_WINDOW_S):
+                _toast_dedup["ts"] = now
+                return current_toasts or []
+            _toast_dedup["sig"] = sig
+            _toast_dedup["ts"] = now
 
             # Icon mapping
             icon_map = {

--- a/nanometa_live/app/callbacks/readiness.py
+++ b/nanometa_live/app/callbacks/readiness.py
@@ -81,8 +81,16 @@ _readiness_lock = threading.Lock()
 _readiness_last: Dict[str, Any] = {"fingerprint": None, "ts": 0.0}
 
 
-def _readiness_fingerprint(config: Optional[Dict[str, Any]]) -> str:
-    """Hash only the config fields the readiness checks actually read."""
+def _readiness_fingerprint(
+    config: Optional[Dict[str, Any]],
+    watchlist_entries: Optional[list] = None,
+) -> str:
+    """Hash only the inputs the readiness checks actually read.
+
+    Includes the enabled-watchlist signature so toggling pathogens in the
+    Watchlist & Preparation tab recomputes the watchlist checks instead of
+    being skipped by the TTL/dedup short-circuit.
+    """
     if not config:
         return "no-config"
     relevant = {
@@ -93,6 +101,10 @@ def _readiness_fingerprint(config: Optional[Dict[str, Any]]) -> str:
             "offline_mode",
         )
     }
+    relevant["_watchlist"] = sorted(
+        e.get("taxid") for e in (watchlist_entries or [])
+        if e.get("enabled", True) and e.get("taxid")
+    )
     return hashlib.md5(json.dumps(relevant, sort_keys=True).encode()).hexdigest()
 
 
@@ -130,10 +142,12 @@ def register_readiness(app, backend_manager):
         Input("app-config", "data"),
         Input("check-readiness-btn", "n_clicks"),
         State("readiness-state", "data"),
+        State("watchlist-entries-snapshot", "data"),
         background=True,
         manager=background_callback_manager,
     )
-    def update_readiness_state(n_intervals, config, n_clicks, prev_state):
+    def update_readiness_state(n_intervals, config, n_clicks, prev_state,
+                               watchlist_entries):
         """Compute readiness and publish it to the shared Store, deduplicated.
 
         Idle update-interval ticks must not re-run the checker's subprocess
@@ -155,7 +169,7 @@ def register_readiness(app, backend_manager):
             new = _empty_readiness_state("No configuration loaded")
             return no_update if _readiness_unchanged(prev_state, new) else new
 
-        fingerprint = _readiness_fingerprint(config)
+        fingerprint = _readiness_fingerprint(config, watchlist_entries)
         now = time.time()
         if not forced:
             with _readiness_lock:
@@ -165,7 +179,12 @@ def register_readiness(app, backend_manager):
                 return no_update
 
         try:
-            report = ReadinessChecker().check_readiness(config)
+            # Pass the watchlist snapshot: this callback runs in a background
+            # worker where the WatchlistManager singleton is empty, so the
+            # watchlist checks would otherwise always report "not enabled".
+            report = ReadinessChecker().check_readiness(
+                config, watchlist_entries=watchlist_entries
+            )
             new = _serialize_report(report)
         except Exception as e:
             logging.error(f"Readiness check failed: {e}")

--- a/nanometa_live/app/components/config_form.py
+++ b/nanometa_live/app/components/config_form.py
@@ -224,7 +224,7 @@ def _essential_settings_card():
                     ]),
                     dbc.Tooltip(
                         "Folder containing the Kraken2 reference database used to identify organisms. "
-                        "If you do not have one, download it from the Preparation tab.",
+                        "If you do not have one, download it from the Watchlist & Preparation tab.",
                         target="kraken-db-info"
                     ),
                     html.Div(id="kraken-db-feedback", className="mt-1")
@@ -570,8 +570,8 @@ def _confirmation_testing_card():
             html.Div([
                 html.I(className="bi bi-info-circle me-2"),
                 html.Span(
-                    "Reference genomes are downloaded in the Preparation tab. "
-                    "Enable the organisms you want to monitor in the Watchlist tab first.",
+                    "Reference genomes are downloaded in the Watchlist & Preparation tab, "
+                    "where you also enable the organisms you want to monitor.",
                     className="text-muted small"
                 )
             ], className="mt-2")
@@ -663,7 +663,7 @@ def _database_settings_item():
                     html.I(className="bi bi-info-circle text-info me-2"),
                     html.Span(
                         "Taxonomy mapping is handled automatically. "
-                        "Database downloads are available in the Preparation tab.",
+                        "Database downloads are available in the Watchlist & Preparation tab.",
                         className="text-muted small"
                     )
                 ], className="mt-2"),

--- a/nanometa_live/app/layouts/config_layout.py
+++ b/nanometa_live/app/layouts/config_layout.py
@@ -26,6 +26,17 @@ def create_config_layout():
         dcc.Store(id="refresh-form-trigger", data=False),
         # Track whether form has been initialized (to suppress initial "Modified" badge)
         dcc.Store(id="config-form-initialized", data=False),
+        # Session-scoped draft of unsaved form edits. Switching to another tab
+        # re-runs initialize_form_from_config (via refresh-form-trigger on
+        # active_tab change), which would otherwise repopulate from the saved
+        # config and discard in-progress edits. The draft is overlaid on load so
+        # edits survive a tab switch; it is cleared on Load/Reset.
+        dcc.Store(id="config-form-draft", storage_type="session"),
+        # Sink for the clientside tab-change tooltip-dismiss callback. dbc
+        # tooltips/popovers render into a portal and can linger visible after
+        # the operator switches tabs (the hover/focus target is hidden, not
+        # left). The callback removes any stray portal nodes on tab change.
+        dcc.Store(id="tooltip-dismiss-trigger"),
 
         # Workflow step indicator
         WorkflowStepper(active_step=1),
@@ -333,8 +344,10 @@ def create_config_layout():
                 html.Small([
                     html.I(className="bi bi-info-circle me-1 text-muted"),
                     html.Span(
-                        "Click 'Apply Settings' to use these parameters. "
-                        "Settings are saved automatically and restored on next launch. "
+                        "Click 'Apply Settings' to save and use these parameters; "
+                        "the applied configuration is restored on next launch. "
+                        "Unsaved edits are kept while you switch tabs but are only "
+                        "persisted when you click 'Apply Settings'. "
                         "Use 'Save for Later' to store named presets.",
                         className="text-muted",
                     )

--- a/nanometa_live/app/layouts/validation_layout.py
+++ b/nanometa_live/app/layouts/validation_layout.py
@@ -513,9 +513,9 @@ def create_validation_layout() -> html.Div:
                     html.Li([
                         html.Strong("Scope: "),
                         "validation runs only for species you have enabled in the ",
-                        html.Em("Watchlist"),
+                        html.Em("Watchlist & Preparation"),
                         " tab and for which a reference genome has been downloaded ",
-                        "(Preparation tab). A Kraken2 hit on the Organism tab will not ",
+                        "(same tab). A Kraken2 hit on the Organisms tab will not ",
                         "appear here unless those two preconditions are met.",
                     ]),
                     html.Li([

--- a/nanometa_live/app/layouts/watchlist_layout.py
+++ b/nanometa_live/app/layouts/watchlist_layout.py
@@ -354,8 +354,9 @@ def _create_pathogens_table_section() -> dbc.Card:
                                style={"fontSize": "0.7rem", "cursor": "help"}),
                         dbc.Tooltip(
                             "Whether this organism was found in the species "
-                            "identification database. If 'Not Scanned', run "
-                            "'Rescan DB' in the Preparation tab.",
+                            "identification database. If 'Not Scanned', click "
+                            "'Scan Database' in the 'Verify Watchlist Against "
+                            "Database' card on this tab.",
                             target="dbmatch-header-info",
                             placement="top",
                         ),
@@ -367,7 +368,8 @@ def _create_pathogens_table_section() -> dbc.Card:
                                style={"fontSize": "0.7rem", "cursor": "help"}),
                         dbc.Tooltip(
                             "Reference genome status. Genomes are used for "
-                            "confirmation testing. Download them in the Preparation tab.",
+                            "confirmation testing. Download them in the 'Prepare "
+                            "for Analysis' section on this tab.",
                             target="genome-header-info",
                             placement="top",
                         ),

--- a/nanometa_live/app/tabs/config_tab.py
+++ b/nanometa_live/app/tabs/config_tab.py
@@ -51,6 +51,26 @@ def register_config_callbacks(app: Dash, backend_manager: BackendManager):
         backend_manager: Backend manager instance
     """
 
+    # Dismiss any lingering dbc tooltip/popover portals when the operator
+    # switches tabs. dbc renders these into a detached portal node; when the
+    # hover/focus target is hidden by a tab change the node can stay visible.
+    # Removing the stray nodes is safe -- dbc re-creates them on the next hover.
+    app.clientside_callback(
+        """
+        function(active_tab) {
+            try {
+                document.querySelectorAll('.tooltip, .popover').forEach(function(el) {
+                    if (el && el.parentNode) { el.parentNode.removeChild(el); }
+                });
+            } catch (e) {}
+            return active_tab;
+        }
+        """,
+        Output("tooltip-dismiss-trigger", "data"),
+        Input("tabs", "active_tab"),
+        prevent_initial_call=True,
+    )
+
     # Trigger form initialization on app startup
     # This fires once when the config-tab first renders
     @app.callback(
@@ -144,6 +164,7 @@ def register_config_callbacks(app: Dash, backend_manager: BackendManager):
             Output("load-config-modal", "is_open", allow_duplicate=True),
             Output("notification-trigger", "data", allow_duplicate=True),
             Output("refresh-form-trigger", "data", allow_duplicate=True),
+            Output("config-form-draft", "data", allow_duplicate=True),
         ],
         Input({"type": "load-config-item", "index": dash.ALL}, "n_clicks"),
         State("available-configs", "children"),
@@ -153,12 +174,12 @@ def register_config_callbacks(app: Dash, backend_manager: BackendManager):
     def load_selected_config(n_clicks, available_configs_json, app_config):
         """Load the selected configuration."""
         if not any(n_clicks) or not ctx.triggered_id:
-            return no_update, no_update, no_update, no_update
+            return no_update, no_update, no_update, no_update, no_update
 
         # Find which button was clicked (pattern-matching ID returns a dict)
         triggered_id = ctx.triggered_id
         if not isinstance(triggered_id, dict) or "index" not in triggered_id:
-            return no_update, no_update, no_update, no_update
+            return no_update, no_update, no_update, no_update, no_update
 
         trigger_idx = triggered_id["index"]
 
@@ -179,6 +200,7 @@ def register_config_callbacks(app: Dash, backend_manager: BackendManager):
                     "color": "success",
                 },
                 True,  # Trigger form refresh
+                None,  # Clear any unsaved draft so the loaded config wins
             )
 
         except Exception as e:
@@ -190,6 +212,7 @@ def register_config_callbacks(app: Dash, backend_manager: BackendManager):
                     "message": f"Failed to load configuration: {str(e)}",
                     "color": "danger",
                 },
+                no_update,
                 no_update,
             )
 
@@ -388,6 +411,7 @@ def register_config_callbacks(app: Dash, backend_manager: BackendManager):
             Output("app-config", "data", allow_duplicate=True),
             Output("notification-trigger", "data", allow_duplicate=True),
             Output("refresh-form-trigger", "data", allow_duplicate=True),
+            Output("config-form-draft", "data", allow_duplicate=True),
         ],
         Input("reset-config-confirm", "n_clicks"),
         State("app-data-dir", "data"),
@@ -396,7 +420,7 @@ def register_config_callbacks(app: Dash, backend_manager: BackendManager):
     def reset_config(n_clicks, data_dir):
         """Reset the configuration to defaults after user confirms."""
         if not n_clicks:
-            return no_update, no_update, no_update
+            return no_update, no_update, no_update, no_update
 
         try:
             config_loader = ConfigLoader(os.path.join(data_dir, "configs"))
@@ -406,13 +430,13 @@ def register_config_callbacks(app: Dash, backend_manager: BackendManager):
                 "title": "Configuration Reset",
                 "message": "All settings have been restored to defaults",
                 "color": "info",
-            }, True  # Trigger form refresh
+            }, True, None  # Trigger form refresh; clear unsaved draft
         except Exception as e:
             return no_update, {
                 "title": "Error",
                 "message": f"Failed to reset configuration: {str(e)}",
                 "color": "danger",
-            }, no_update
+            }, no_update, no_update
 
     # Apply Config Changes Callback - THE SINGLE POINT OF CONFIG UPDATE
     # All form values (including species) are read here and committed to app-config
@@ -710,9 +734,19 @@ def register_config_callbacks(app: Dash, backend_manager: BackendManager):
         ],
         Input("refresh-form-trigger", "data"),
         State("app-config", "data"),
+        State("config-form-draft", "data"),
     )
-    def initialize_form_from_config(refresh_trigger, config):
-        """Initialize form fields from the current configuration."""
+    def initialize_form_from_config(refresh_trigger, config, draft):
+        """Initialize form fields from the current configuration.
+
+        Unsaved edits are restored from ``config-form-draft`` (a session Store
+        written by detect_form_changes) so switching tabs and returning does not
+        discard in-progress edits. The draft is overlaid on top of the saved
+        config; it is cleared on Load/Reset so those authoritative actions win.
+        """
+        # Overlay any unsaved draft edits on top of the saved config so the
+        # operator's in-progress changes survive a tab switch.
+        config = {**(config or {}), **(draft or {})}
         if not config:
             return [no_update] * 42
 
@@ -1549,6 +1583,7 @@ def register_config_callbacks(app: Dash, backend_manager: BackendManager):
         [
             Output("config-modified", "data", allow_duplicate=True),
             Output("config-form-initialized", "data", allow_duplicate=True),
+            Output("config-form-draft", "data", allow_duplicate=True),
         ],
         [
             Input("analysis-name-input", "value"),
@@ -1620,11 +1655,12 @@ def register_config_callbacks(app: Dash, backend_manager: BackendManager):
         snapshot. Comparison mirrors build_config_from_form via the
         config_form_dirty helper, so all operator-editable fields are covered."""
         # Form (re)initialization cascades value changes into this callback;
-        # consume the initialized flag and skip the check.
+        # consume the initialized flag and skip the check. Leave the draft
+        # untouched (no_update) so a tab-switch re-init does not wipe it.
         if form_initialized:
-            return no_update, False
+            return no_update, False, no_update
         if not saved_snapshot:
-            return no_update, no_update
+            return no_update, no_update, no_update
 
         form = {
             "analysis_name": analysis_name or "",
@@ -1674,7 +1710,11 @@ def register_config_callbacks(app: Dash, backend_manager: BackendManager):
             ),
             "min_reads_for_validation": min_reads_for_validation,
         }
-        return config_form_dirty(saved_snapshot, form=form), no_update
+        dirty = config_form_dirty(saved_snapshot, form=form)
+        # Persist the in-progress edits as a session draft when the form differs
+        # from the saved snapshot; clear it once the form matches saved again so
+        # a stale draft cannot resurrect discarded edits on the next tab visit.
+        return dirty, no_update, (form if dirty else None)
 
     # Callback: Mark as not modified after Apply (config matches current form)
     @app.callback(

--- a/nanometa_live/app/tabs/preparation_tab.py
+++ b/nanometa_live/app/tabs/preparation_tab.py
@@ -975,6 +975,10 @@ def register_preparation_callbacks(app):
                 "taxid": e.get("taxid", 0),
                 "rank": e.get("api_rank", "species"),
                 "names_alt": e.get("names_alt", []),
+                # Carry the enabled flag so background-worker consumers (e.g.
+                # the readiness checker) can filter to the active set without
+                # the empty WatchlistManager singleton.
+                "enabled": e.get("enabled", True),
             }
             for e in entries
         ]

--- a/nanometa_live/app/tabs/watchlist_tab.py
+++ b/nanometa_live/app/tabs/watchlist_tab.py
@@ -564,12 +564,10 @@ def register_watchlist_callbacks(app: Dash) -> None:
                             [
                                 "The watchlist cannot be checked against the "
                                 "Kraken2 database until the taxonomy index "
-                                "has been built. Open the ",
-                                html.Strong("Preparation"),
-                                " tab and click ",
+                                "has been built. Click ",
                                 html.Strong("Scan Database"),
                                 " in the 'Verify Watchlist Against Database' "
-                                "card to (re)build the index.",
+                                "card on this tab to (re)build the index.",
                             ],
                             className="mb-0 text-muted small",
                         ),
@@ -975,7 +973,7 @@ def register_watchlist_callbacks(app: Dash) -> None:
                 payloads.append(entry.to_dict())
 
         validated = summary.get("validated", 0)
-        set_progress((100, f"Validated {validated} of {total}", api_label))
+        set_progress((100, f"Validated {validated} of {total} entries", api_label))
 
         return {
             "results": payloads,
@@ -984,6 +982,9 @@ def register_watchlist_callbacks(app: Dash) -> None:
             "total": total,
             "apis": apis_used,
             "offline": offline_mode,
+            # {host: human reason} when an API host failed -- lets the toast
+            # explain a partial result instead of a silent count.
+            "api_failures": summary.get("api_failures") or {},
         }
 
     @app.callback(
@@ -1023,15 +1024,22 @@ def register_watchlist_callbacks(app: Dash) -> None:
         total = payload.get("total", 0)
         failed = payload.get("failed", 0)
         apis = payload.get("apis", [])
+        api_failures = payload.get("api_failures") or {}
         detail = f"APIs: {', '.join(apis) if apis else 'none'}"
         if payload.get("offline"):
             detail += " | offline mode: cached data only"
         elif failed:
             detail += f" | {failed} failed"
+        # Name the failing host(s) and cause so a partial result is explained
+        # (e.g. "GTDB: SSL certificate verification failed") rather than a
+        # silent low count from a tripped circuit breaker.
+        if api_failures:
+            reasons = "; ".join(f"{host} {reason}" for host, reason in api_failures.items())
+            detail += f" | {reasons}"
 
         new_refresh = (current_refresh or 0) + 1
         toast = {
-            "type": "success" if validated else "info",
+            "type": "success" if validated and not failed else "warning" if failed else "info",
             "title": "Validation complete",
             "message": f"Validated {validated} of {total} entries. {detail}",
         }

--- a/nanometa_live/core/taxonomy/taxonomy_api.py
+++ b/nanometa_live/core/taxonomy/taxonomy_api.py
@@ -218,6 +218,38 @@ class TaxonomyCache:
         }
 
 
+def _classify_request_error(exc: Exception) -> str:
+    """Map a requests exception to a short, operator-facing reason code."""
+    if isinstance(exc, requests.exceptions.SSLError):
+        return "ssl_error"
+    if isinstance(exc, requests.exceptions.Timeout):
+        return "timeout"
+    if isinstance(exc, requests.exceptions.HTTPError):
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        return f"http_{status}" if status else "http_error"
+    if isinstance(exc, requests.exceptions.ConnectionError):
+        return "connection_error"
+    return "network_error"
+
+
+# Human-readable phrasing for the reason codes above, for UI toasts.
+_REASON_LABELS = {
+    "ssl_error": "SSL certificate verification failed",
+    "timeout": "request timed out",
+    "connection_error": "could not connect",
+    "bad_response": "unexpected response",
+    "http_400": "rejected the request (HTTP 400)",
+    "http_error": "returned an HTTP error",
+    "network_error": "network error",
+    "circuit_open": "skipped after repeated failures",
+}
+
+
+def describe_failure_reason(reason: str) -> str:
+    """Return a human phrase for a circuit-breaker reason code."""
+    return _REASON_LABELS.get(reason, reason.replace("_", " "))
+
+
 class TaxonomyAPIClient(ABC):
     """Base class for taxonomy API clients."""
 
@@ -233,6 +265,34 @@ class TaxonomyAPIClient(ABC):
     _CIRCUIT_FAILURE_THRESHOLD: int = 3
     _circuit_failures: Dict[str, int] = {}
     _circuit_open: Dict[str, bool] = {}
+    # Last failure reason per host (ssl_error / http_4xx / timeout /
+    # connection_error / network_error), so callers can tell the operator
+    # WHY a host failed rather than reporting a silent partial count.
+    _circuit_last_reason: Dict[str, str] = {}
+
+    # NCBI taxids at/above this synthetic band are pseudo-taxids minted by
+    # the watchlist for name-only/custom entries (see watchlist_manager
+    # _PSEUDO_TAXID_BASE). They are NOT real NCBI ids; sending one to NCBI
+    # esummary returns HTTP 400, so by-taxid lookups must skip them.
+    _PSEUDO_TAXID_MIN: int = 2_000_000_000
+
+    @classmethod
+    def reset_circuit_breaker(cls) -> None:
+        """Clear all circuit-breaker state for this process.
+
+        Called at the start of a bulk validation run so a transient host
+        failure from an earlier run cannot silently short-circuit the whole
+        new run. The in-run breaker still trips after the threshold, so a
+        genuinely-down host does not stall the rest of the batch.
+        """
+        cls._circuit_failures.clear()
+        cls._circuit_open.clear()
+        cls._circuit_last_reason.clear()
+
+    @classmethod
+    def circuit_failure_summary(cls) -> Dict[str, str]:
+        """Return {host: last_failure_reason} for hosts that have failed."""
+        return dict(cls._circuit_last_reason)
 
     def __init__(
         self,
@@ -278,8 +338,9 @@ class TaxonomyAPIClient(ABC):
             return url
 
     @classmethod
-    def _circuit_record_failure(cls, url: str) -> None:
+    def _circuit_record_failure(cls, url: str, reason: str = "network_error") -> None:
         host = cls._circuit_host(url)
+        cls._circuit_last_reason[host] = reason
         cls._circuit_failures[host] = cls._circuit_failures.get(host, 0) + 1
         if cls._circuit_failures[host] >= cls._CIRCUIT_FAILURE_THRESHOLD:
             if not cls._circuit_open.get(host):
@@ -368,16 +429,18 @@ class TaxonomyAPIClient(ABC):
                 # surfaces the user-visible WARNING once the threshold
                 # is crossed, so individual failures stay at DEBUG.
                 logger.debug("API request failed (SSL fallback): %s - %s", url, e)
-                self._circuit_record_failure(url)
+                # The host's TLS could not be verified even with the fallback;
+                # report it as an SSL error so the operator can fix trust.
+                self._circuit_record_failure(url, "ssl_error")
                 return None
 
         except requests.exceptions.RequestException as e:
             logger.debug(f"API request failed: {url} - {e}")
-            self._circuit_record_failure(url)
+            self._circuit_record_failure(url, _classify_request_error(e))
             return None
         except json.JSONDecodeError as e:
             logger.warning(f"Failed to parse API response: {e}")
-            self._circuit_record_failure(url)
+            self._circuit_record_failure(url, "bad_response")
             return None
 
     @abstractmethod
@@ -509,6 +572,14 @@ class NCBIClient(TaxonomyAPIClient):
                 logger.debug(f"Offline cache hit for taxid: {taxid}")
                 return NCBIResult.from_dict(offline_data) if isinstance(offline_data, dict) else None
             logger.debug(f"Offline mode: no cached data for taxid {taxid}")
+            return None
+
+        # Pseudo-taxids (name-only / custom watchlist entries) are not real
+        # NCBI ids -- esummary returns HTTP 400 for them, which would trip the
+        # circuit breaker and silently fail the rest of a bulk run. Skip the
+        # request; the caller falls back to search_by_name.
+        if taxid <= 0 or taxid >= self._PSEUDO_TAXID_MIN:
+            logger.debug("Skipping NCBI by-taxid for non-real taxid %s", taxid)
             return None
 
         # Get summary

--- a/nanometa_live/core/watchlist/watchlist_manager.py
+++ b/nanometa_live/core/watchlist/watchlist_manager.py
@@ -1425,6 +1425,16 @@ class WatchlistManager:
                 if not entry.validated
             ]
 
+        # Reset the per-host circuit breaker so a transient host failure from
+        # an earlier run cannot silently short-circuit this whole run. The
+        # in-run breaker still trips after the threshold for a genuinely-down
+        # host, so the batch never stalls.
+        try:
+            from nanometa_live.core.taxonomy.taxonomy_api import TaxonomyAPIClient
+            TaxonomyAPIClient.reset_circuit_breaker()
+        except ImportError:
+            pass
+
         results = {
             "validated": 0,
             "failed": 0,
@@ -1452,6 +1462,21 @@ class WatchlistManager:
                 results["validated"] += 1
             else:
                 results["failed"] += 1
+
+        # Surface which API host(s) failed and why, so the UI can report a
+        # cause instead of a silent partial count.
+        try:
+            from nanometa_live.core.taxonomy.taxonomy_api import (
+                TaxonomyAPIClient, describe_failure_reason,
+            )
+            summary = TaxonomyAPIClient.circuit_failure_summary()
+            if summary:
+                results["api_failures"] = {
+                    host: describe_failure_reason(reason)
+                    for host, reason in summary.items()
+                }
+        except ImportError:
+            pass
 
         logger.info(f"Bulk validation: {results['validated']} validated, "
                    f"{results['failed']} failed out of {total}")

--- a/nanometa_live/core/workflow/readiness_checker.py
+++ b/nanometa_live/core/workflow/readiness_checker.py
@@ -89,6 +89,7 @@ class ReadinessChecker:
         self,
         config: Dict[str, Any],
         nanometa_home: Optional[str] = None,
+        watchlist_entries: Optional[List[Dict[str, Any]]] = None,
     ) -> ReadinessReport:
         """
         Run all readiness checks.
@@ -96,10 +97,19 @@ class ReadinessChecker:
         Args:
             config: Application configuration dict.
             nanometa_home: Path to ~/.nanometa (or equivalent).
+            watchlist_entries: Optional snapshot of watchlist entries (dicts with
+                ``taxid``/``name``/``enabled``). REQUIRED when this runs in a
+                DiskcacheManager background worker, where the WatchlistManager
+                singleton is empty: without it the watchlist checks would always
+                report "not enabled" even when the operator has enabled entries
+                in the main process. When omitted, the singleton is consulted
+                (correct for in-process callers).
 
         Returns:
             ReadinessReport with all check results.
         """
+        active_watchlist = self._resolve_active_watchlist(watchlist_entries)
+
         if nanometa_home is None:
             # Prefer the operator-configured data_dir; the legacy
             # ``~/.nanometa`` fallback only fires when no config has
@@ -166,9 +176,9 @@ class ReadinessChecker:
         report.checks.append(self._check_disk_space(config))
 
         # === Data completeness (warning) ===
-        report.checks.append(self._check_watchlist_active(config))
-        report.checks.append(self._check_watchlist_genomes(config, home))
-        report.checks.append(self._check_blast_dbs(config, home))
+        report.checks.append(self._check_watchlist_active(config, active_watchlist))
+        report.checks.append(self._check_watchlist_genomes(config, home, active_watchlist))
+        report.checks.append(self._check_blast_dbs(config, home, active_watchlist))
 
         # === Informational ===
         report.checks.append(self._check_nextflow_version())
@@ -472,50 +482,83 @@ class ReadinessChecker:
 
     # -- Data completeness checks --
 
-    def _check_watchlist_active(self, config: Dict[str, Any]) -> CheckResult:
-        """Check whether at least one watchlist is enabled for pathogen screening."""
-        try:
-            from nanometa_live.core.watchlist.watchlist_manager import get_watchlist_manager
-            wm = get_watchlist_manager()
-            active = wm.get_active_entries()
-            if active:
-                count = len(active)
-                return CheckResult(
-                    "Watchlist Active", True, Severity.WARNING,
-                    f"{count} pathogen(s) enabled for screening"
-                )
-            return CheckResult(
-                "Watchlist Active", False, Severity.WARNING,
-                "No watchlist enabled - enable pathogens in the Watchlist tab"
-            )
-        except (ImportError, AttributeError, OSError):
-            # Check config for watchlist section as fallback
-            wl = config.get("watchlist", {})
-            if isinstance(wl, dict) and wl.get("enabled_watchlists"):
-                return CheckResult(
-                    "Watchlist Active", True, Severity.WARNING,
-                    "Watchlist configured (not yet loaded)"
-                )
-            return CheckResult(
-                "Watchlist Active", False, Severity.WARNING,
-                "No watchlist enabled - enable pathogens in the Watchlist tab"
-            )
+    def _resolve_active_watchlist(
+        self, watchlist_entries: Optional[List[Dict[str, Any]]]
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Return enabled watchlist entries as ``[{name, taxid}]`` dicts.
 
-    def _check_watchlist_genomes(self, config: Dict[str, Any], home: Path) -> CheckResult:
+        Prefers the injected snapshot (so the watchlist checks work in a
+        DiskcacheManager background worker, where the WatchlistManager singleton
+        is empty); falls back to the singleton for in-process callers. Returns
+        ``None`` only when neither source is available -- the checks treat that
+        as "could not determine" and use their directory/config fallback, which
+        is distinct from an empty list ("watchlist loaded but nothing enabled").
+        """
+        if watchlist_entries is not None:
+            resolved: List[Dict[str, Any]] = []
+            for e in watchlist_entries:
+                if not e.get("enabled", True):
+                    continue
+                taxid = e.get("taxid")
+                if not taxid:
+                    continue
+                resolved.append({"name": e.get("name", f"taxid {taxid}"), "taxid": taxid})
+            return resolved
         try:
             from nanometa_live.core.watchlist.watchlist_manager import get_watchlist_manager
-            from nanometa_live.core.utils.genome_manager import get_genome_manager
             wm = get_watchlist_manager()
-            gm = get_genome_manager(config.get("genome_cache_dir") or str(home))
             active = wm.get_active_entries()
-            if not active:
+            return [
+                {"name": v.name, "taxid": v.taxid}
+                for v in active.values() if v.taxid
+            ]
+        except (ImportError, AttributeError, OSError):
+            return None
+
+    def _check_watchlist_active(
+        self, config: Dict[str, Any],
+        active_entries: Optional[List[Dict[str, Any]]],
+    ) -> CheckResult:
+        """Check whether at least one watchlist entry is enabled for screening."""
+        if active_entries is not None:
+            if active_entries:
+                return CheckResult(
+                    "Watchlist Active", True, Severity.WARNING,
+                    f"{len(active_entries)} pathogen(s) enabled for screening"
+                )
+            return CheckResult(
+                "Watchlist Active", False, Severity.WARNING,
+                "No watchlist enabled - enable pathogens in the Watchlist & Preparation tab"
+            )
+        # Could not determine from snapshot/singleton -- fall back to config.
+        wl = config.get("watchlist", {})
+        if isinstance(wl, dict) and wl.get("enabled_watchlists"):
+            return CheckResult(
+                "Watchlist Active", True, Severity.WARNING,
+                "Watchlist configured (not yet loaded)"
+            )
+        return CheckResult(
+            "Watchlist Active", False, Severity.WARNING,
+            "No watchlist enabled - enable pathogens in the Watchlist & Preparation tab"
+        )
+
+    def _check_watchlist_genomes(
+        self, config: Dict[str, Any], home: Path,
+        active_entries: Optional[List[Dict[str, Any]]],
+    ) -> CheckResult:
+        try:
+            from nanometa_live.core.utils.genome_manager import get_genome_manager
+            gm = get_genome_manager(config.get("genome_cache_dir") or str(home))
+            if active_entries is None:
+                raise AttributeError("watchlist unavailable")
+            if not active_entries:
                 return CheckResult(
                     "Watchlist Genomes", False, Severity.WARNING,
-                    "No enabled watchlist entries — enable pathogens in the Watchlist tab"
+                    "No enabled watchlist entries — enable pathogens in the Watchlist & Preparation tab"
                 )
-            missing = [e.name for e in active.values()
-                       if e.taxid and not gm.has_genome(e.taxid)]
-            total = sum(1 for e in active.values() if e.taxid)
+            missing = [e["name"] for e in active_entries
+                       if e["taxid"] and not gm.has_genome(e["taxid"])]
+            total = sum(1 for e in active_entries if e["taxid"])
             have = total - len(missing)
             if not missing:
                 return CheckResult(
@@ -544,7 +587,10 @@ class ReadinessChecker:
                 "No reference genomes downloaded"
             )
 
-    def _check_blast_dbs(self, config: Dict[str, Any], home: Path) -> CheckResult:
+    def _check_blast_dbs(
+        self, config: Dict[str, Any], home: Path,
+        active_entries: Optional[List[Dict[str, Any]]],
+    ) -> CheckResult:
         blast_enabled = config.get("blast_validation", False)
         if isinstance(blast_enabled, str):
             blast_enabled = blast_enabled.lower() in ("true", "yes", "1")
@@ -554,19 +600,18 @@ class ReadinessChecker:
                 "BLAST validation not enabled"
             )
         try:
-            from nanometa_live.core.watchlist.watchlist_manager import get_watchlist_manager
             from nanometa_live.core.utils.genome_manager import get_genome_manager
-            wm = get_watchlist_manager()
             gm = get_genome_manager(config.get("genome_cache_dir") or str(home))
-            active = wm.get_active_entries()
-            if not active:
+            if active_entries is None:
+                raise AttributeError("watchlist unavailable")
+            if not active_entries:
                 return CheckResult(
                     "BLAST Databases", False, Severity.WARNING,
-                    "No enabled watchlist entries — enable pathogens in the Watchlist tab"
+                    "No enabled watchlist entries — enable pathogens in the Watchlist & Preparation tab"
                 )
-            missing = [e.name for e in active.values()
-                       if e.taxid and not gm.has_blast_db(e.taxid)]
-            total = sum(1 for e in active.values() if e.taxid)
+            missing = [e["name"] for e in active_entries
+                       if e["taxid"] and not gm.has_blast_db(e["taxid"])]
+            total = sum(1 for e in active_entries if e["taxid"])
             have = total - len(missing)
             if not missing:
                 return CheckResult(

--- a/tests/test_readiness_watchlist_snapshot.py
+++ b/tests/test_readiness_watchlist_snapshot.py
@@ -1,0 +1,64 @@
+"""Readiness watchlist checks must use the injected snapshot.
+
+Regression for the local-server report where the readiness checklist said the
+watchlist was "not enabled" even though entries were enabled and genomes
+downloaded: the readiness callback runs in a DiskcacheManager worker where the
+WatchlistManager singleton is empty, so it must read the watchlist from the
+``watchlist-entries-snapshot`` store instead.
+"""
+
+import pytest
+
+from nanometa_live.core.workflow.readiness_checker import ReadinessChecker
+
+
+def _checker():
+    return ReadinessChecker()
+
+
+def test_resolve_active_watchlist_filters_enabled_and_taxid():
+    rc = _checker()
+    snapshot = [
+        {"name": "E. coli", "taxid": 562, "enabled": True},
+        {"name": "disabled bug", "taxid": 999, "enabled": False},
+        {"name": "no taxid", "taxid": 0, "enabled": True},
+    ]
+    active = rc._resolve_active_watchlist(snapshot)
+    assert active == [{"name": "E. coli", "taxid": 562}]
+
+
+def test_resolve_active_watchlist_empty_snapshot_is_definitive():
+    # An explicit (possibly empty) snapshot means "loaded, nothing enabled" --
+    # NOT "could not determine", so it must return a list (here empty).
+    rc = _checker()
+    assert rc._resolve_active_watchlist([]) == []
+
+
+def test_watchlist_active_uses_snapshot_enabled_entries():
+    rc = _checker()
+    active = rc._resolve_active_watchlist(
+        [{"name": "E. coli", "taxid": 562, "enabled": True}]
+    )
+    result = rc._check_watchlist_active({}, active)
+    assert result.passed is True
+    assert "1 pathogen" in result.message
+
+
+def test_watchlist_active_reports_not_enabled_for_empty_snapshot():
+    rc = _checker()
+    result = rc._check_watchlist_active({}, [])
+    assert result.passed is False
+    assert "No watchlist enabled" in result.message
+
+
+def test_check_readiness_threads_snapshot_into_watchlist_checks():
+    """End-to-end: passing watchlist_entries makes the Watchlist Active check
+    pass without any populated singleton."""
+    rc = _checker()
+    report = rc.check_readiness(
+        {"kraken_db": ""},
+        nanometa_home="/tmp/nm_readiness_test_home",
+        watchlist_entries=[{"name": "E. coli", "taxid": 562, "enabled": True}],
+    )
+    active = [c for c in report.checks if c.name == "Watchlist Active"]
+    assert active and active[0].passed is True

--- a/tests/test_taxonomy_api_resilience.py
+++ b/tests/test_taxonomy_api_resilience.py
@@ -1,0 +1,74 @@
+"""Resilience of the taxonomy API clients and circuit breaker.
+
+Covers the local-server report where Verify Taxonomy IDs validated only 1 of N
+entries: the NCBI HTTP 400 (a pseudo-taxid sent to esummary) tripped the
+per-host circuit breaker, which then silently failed the rest of the run.
+"""
+
+import requests
+
+from nanometa_live.core.taxonomy.taxonomy_api import (
+    NCBIClient,
+    TaxonomyAPIClient,
+    _classify_request_error,
+    describe_failure_reason,
+)
+
+
+def test_get_by_taxid_skips_pseudo_taxid_without_request(monkeypatch):
+    """A synthetic pseudo-taxid (>= 2e9) must not hit NCBI esummary (HTTP 400);
+    get_by_taxid returns None without making a request."""
+    client = NCBIClient()
+
+    called = {"hit": False}
+
+    def _boom(*args, **kwargs):
+        called["hit"] = True
+        raise AssertionError("network call must not happen for a pseudo-taxid")
+
+    monkeypatch.setattr(client, "_make_request", _boom)
+    assert client.get_by_taxid(2_000_000_123) is None
+    assert called["hit"] is False
+    # taxid 0 / negative are likewise non-real and skipped.
+    assert client.get_by_taxid(0) is None
+    assert called["hit"] is False
+
+
+def test_reset_circuit_breaker_clears_state():
+    TaxonomyAPIClient._circuit_open["example.com"] = True
+    TaxonomyAPIClient._circuit_failures["example.com"] = 5
+    TaxonomyAPIClient._circuit_last_reason["example.com"] = "ssl_error"
+    TaxonomyAPIClient.reset_circuit_breaker()
+    assert TaxonomyAPIClient._circuit_open == {}
+    assert TaxonomyAPIClient._circuit_failures == {}
+    assert TaxonomyAPIClient._circuit_last_reason == {}
+
+
+def test_circuit_failure_summary_reports_reason():
+    TaxonomyAPIClient.reset_circuit_breaker()
+    TaxonomyAPIClient._circuit_record_failure(
+        "https://api.gtdb.ecogenomic.org/x", "ssl_error"
+    )
+    summary = TaxonomyAPIClient.circuit_failure_summary()
+    assert summary.get("api.gtdb.ecogenomic.org") == "ssl_error"
+    TaxonomyAPIClient.reset_circuit_breaker()
+
+
+def test_classify_request_error_maps_http_400():
+    resp = requests.Response()
+    resp.status_code = 400
+    err = requests.exceptions.HTTPError(response=resp)
+    assert _classify_request_error(err) == "http_400"
+
+
+def test_classify_request_error_maps_families():
+    assert _classify_request_error(requests.exceptions.SSLError()) == "ssl_error"
+    assert _classify_request_error(requests.exceptions.Timeout()) == "timeout"
+    assert _classify_request_error(
+        requests.exceptions.ConnectionError()
+    ) == "connection_error"
+
+
+def test_describe_failure_reason_is_human_readable():
+    assert "SSL" in describe_failure_reason("ssl_error")
+    assert describe_failure_reason("http_400")  # non-empty phrasing

--- a/tests/test_watchlist_empty_state.py
+++ b/tests/test_watchlist_empty_state.py
@@ -74,11 +74,14 @@ def test_empty_taxmap_collection_renders_empty_state_not_not_found():
     # ...but a single empty-state card stands in for the rows.
     assert len(rows) == 1, "exactly one empty-state node, not N 'Not Found' rows"
 
-    # The empty-state copy should name the Preparation tab and the Scan
-    # Database control so the operator knows where to act.
+    # The empty-state copy should name the Scan Database control on THIS tab
+    # (Watchlist & Preparation is one merged tab), not tell the operator to
+    # open a now-nonexistent separate Preparation tab.
     rendered = str(rows[0])
     assert "Taxonomy index" in rendered
-    assert "Preparation" in rendered
     assert "Scan Database" in rendered
+    assert "this tab" in rendered
+    # The stale cross-tab instruction must be gone.
+    assert "Preparation tab" not in rendered
     # And must not render the legacy "Not Found" text per row.
     assert "Not Found" not in rendered


### PR DESCRIPTION
Resolves the nanometa_live-side issues from local-server user testing (4 June).
The analysis-killing **BLAST/minimap validation crash is fixed separately in
nanometanf** (`fix/validation-versions-batch-crash`) — it is a pipeline bug, not
a GUI bug.

## Fixes

**B — Readiness "watchlist not enabled" despite enabled entries.** `update_readiness_state`
runs in a DiskcacheManager worker where the `WatchlistManager` singleton is empty, so
every watchlist check reported "not enabled". It now passes
`watchlist-entries-snapshot` into `ReadinessChecker.check_readiness(watchlist_entries=…)`;
the three `_check_watchlist_*` methods use the snapshot's enabled entries. The snapshot
carries `enabled`, and the readiness fingerprint includes it so toggling recomputes.

**C — Verify Taxonomy IDs validated 1 vs all.** The per-host circuit breaker tripped on
real server failures (GTDB SSL cert error, NCBI HTTP 400) and silently failed the rest of
the run. Now the breaker is reset per bulk-validate run, and the failing host + reason
(ssl_error / http_400 / timeout / …) is surfaced in the result toast. Root-caused the NCBI
400: pseudo-taxids (≥ 2e9, name-only/custom entries) were sent to esummary; `get_by_taxid`
now skips non-real taxids.

**D — Toast spam on Start Analysis.** `display_toast` coalesces identical toasts within a
5 s window so a per-entry burst shows once.

**E — "Settings saved automatically" + lost edits.** Reworded the misleading help text
(config is saved on **Apply Settings**). Added a session-scoped `config-form-draft` Store
written by `detect_form_changes` and overlaid by `initialize_form_from_config`, so unsaved
edits survive a tab switch (cleared on Load/Reset). Verified live: a typed value persists
across a tab switch.

**F — Stale empty-state + sticky tooltips.** The taxonomy-index empty state pointed at a
separate "Preparation" tab; rewritten to reference **Scan Database** on this (merged) tab.
Added a clientside tab-change handler that dismisses lingering dbc tooltip/popover portals.

**G — Tab-reorg text sweep.** Replaced stale "Preparation tab" / "Watchlist tab" references
with "Watchlist & Preparation" across the welcome modal, config form, watchlist/validation
layouts, and docs (user-guide, configuration, local-server-testing, runbooks).

## Verification
- Full suite: **2177 passed, 1 skipped**. New unit tests for the readiness snapshot, the
  NCBI pseudo-taxid guard, and the circuit-breaker reset; updated the empty-state test.
- Browser smoke test (`06_pathogen_detected`): all 8 tabs render, **zero
  `/_dash-update-component` 500s**, zero console errors; config-draft round-trip confirmed.

CLAUDE.md updated with the readiness-snapshot requirement and the config-form draft invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)