### PR TITLE
test(pytest): readiness helpers + fastp loader value assertions (installment 3)

### DIFF
--- a/tests/test_qc_loaders_fastp.py
+++ b/tests/test_qc_loaders_fastp.py
@@ -1,0 +1,77 @@
+"""Value-asserting tests for the fastp loaders in core/utils/qc_loaders.py.
+
+Drives the parsers with a generated dataset and checks real relationships
+(before >= after, passed_filter == after, per-sample fan-out) rather than just
+that a non-empty object is returned.
+"""
+
+import os
+import time
+
+import pytest
+
+from nanometa_live.core.utils.qc_loaders import (
+    load_fastp_data,
+    load_fastp_per_sample,
+    get_qc_stats,
+    _empty_fastp_stats,
+)
+from nanometa_live.core.testing.mock_data_generator import (
+    generate_test_dataset,
+    MockDataScenario,
+)
+
+
+@pytest.fixture(scope="module")
+def qc_dir(tmp_path_factory):
+    d = tmp_path_factory.mktemp("qc_loaders_fastp")
+    generate_test_dataset(str(d), scenario=MockDataScenario.PATHOGEN_DETECTED, num_samples=3)
+    old = time.time() - 30
+    for dp, _dirs, files in os.walk(str(d)):
+        for f in files:
+            try:
+                os.utime(os.path.join(dp, f), (old, old))
+            except OSError:
+                pass
+    return str(d)
+
+
+def test_load_fastp_data_aggregate_relationships(qc_dir):
+    stats = load_fastp_data(qc_dir)
+    assert stats["total_reads_before"] > 0
+    # filtering can only remove reads
+    assert stats["total_reads_after"] <= stats["total_reads_before"]
+    assert stats["total_bases_after"] <= stats["total_bases_before"]
+    # reads passing the filter == reads remaining after
+    assert stats["passed_filter"] == stats["total_reads_after"]
+    # removed buckets are non-negative and bounded by what was removed
+    removed = stats["total_reads_before"] - stats["total_reads_after"]
+    assert stats["low_quality"] >= 0 and stats["too_short"] >= 0
+    assert stats["low_quality"] + stats["too_short"] <= removed + 1
+
+
+def test_load_fastp_per_sample_fans_out(qc_dir):
+    rows = load_fastp_per_sample(qc_dir)
+    assert len(rows) == 3                       # three barcodes
+    names = {r["sample"] for r in rows}
+    assert names == {"barcode01", "barcode02", "barcode03"}
+    for r in rows:
+        assert r["reads_after"] > 0
+        assert r["bases_after"] > 0
+    # per-sample reads sum to the aggregate
+    agg = load_fastp_data(qc_dir)
+    assert sum(r["reads_after"] for r in rows) == agg["total_reads_after"]
+
+
+def test_get_qc_stats_reports_fastp_source(qc_dir):
+    qs = get_qc_stats(qc_dir)
+    assert qs["source"] == "fastp"
+    assert qs["total_reads"] > 0
+    assert qs["total_reads_after"] <= qs["total_reads_before"]
+
+
+def test_empty_dir_yields_empty_stats(tmp_path):
+    stats = load_fastp_data(str(tmp_path))
+    assert stats == _empty_fastp_stats()
+    assert stats["total_reads_before"] == 0
+    assert load_fastp_per_sample(str(tmp_path)) == []

--- a/tests/test_readiness_helpers.py
+++ b/tests/test_readiness_helpers.py
@@ -1,0 +1,129 @@
+"""Tests for app/callbacks/readiness.py pure helpers + the badge renderer."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from dash import Dash
+import dash_bootstrap_components as dbc
+
+from nanometa_live.app.callbacks.readiness import (
+    _serialize_report,
+    _empty_readiness_state,
+    _readiness_fingerprint,
+    _readiness_unchanged,
+    register_readiness,
+)
+from dash_test_utils import get_callback_fn
+
+
+def _fake_report(ready=True):
+    check = SimpleNamespace(
+        name="Kraken2 DB", passed=ready,
+        severity=SimpleNamespace(value="critical"), message="db ok",
+    )
+    return SimpleNamespace(
+        ready=ready,
+        summary=lambda: {"total": 1, "passed": 1 if ready else 0,
+                         "failed": 0 if ready else 1,
+                         "critical_failures": 0 if ready else 1, "warnings": 0},
+        checks=[check],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# _serialize_report / _empty_readiness_state
+# --------------------------------------------------------------------------- #
+
+def test_serialize_report():
+    out = _serialize_report(_fake_report(ready=True))
+    assert out["ready"] is True
+    assert out["error"] is None
+    assert out["summary"]["total"] == 1
+    assert out["checks"][0] == {
+        "name": "Kraken2 DB", "passed": True, "severity": "critical", "message": "db ok",
+    }
+    assert "computed_at" in out
+
+
+def test_empty_readiness_state():
+    out = _empty_readiness_state("No configuration loaded")
+    assert out["ready"] is False
+    assert out["error"] == "No configuration loaded"
+    assert out["checks"] == []
+    assert out["summary"]["total"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# _readiness_fingerprint
+# --------------------------------------------------------------------------- #
+
+def test_fingerprint_no_config():
+    assert _readiness_fingerprint(None) == "no-config"
+
+
+def test_fingerprint_changes_with_watchlist():
+    cfg = {"kraken_db": "/db"}
+    fp_none = _readiness_fingerprint(cfg, [])
+    fp_one = _readiness_fingerprint(cfg, [{"taxid": 562, "enabled": True}])
+    assert fp_none != fp_one
+    # disabled entries do not affect the fingerprint
+    fp_disabled = _readiness_fingerprint(cfg, [{"taxid": 562, "enabled": False}])
+    assert fp_disabled == fp_none
+
+
+def test_fingerprint_stable_for_same_inputs():
+    cfg = {"kraken_db": "/db", "blast_validation": True}
+    wl = [{"taxid": 1, "enabled": True}]
+    assert _readiness_fingerprint(cfg, wl) == _readiness_fingerprint(cfg, wl)
+
+
+# --------------------------------------------------------------------------- #
+# _readiness_unchanged
+# --------------------------------------------------------------------------- #
+
+def test_readiness_unchanged():
+    a = _serialize_report(_fake_report(ready=True))
+    b = _serialize_report(_fake_report(ready=True))   # differs only in computed_at
+    assert _readiness_unchanged(a, b) is True
+    assert _readiness_unchanged(None, b) is False
+    c = _serialize_report(_fake_report(ready=False))
+    assert _readiness_unchanged(a, c) is False
+
+
+# --------------------------------------------------------------------------- #
+# render_readiness_badge
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture(scope="module")
+def rd_app():
+    app = Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP], suppress_callback_exceptions=True)
+    register_readiness(app, MagicMock())
+    return app
+
+
+def test_badge_ready(rd_app):
+    fn = get_callback_fn(rd_app, "readiness-badge")
+    children, color, _ = fn(_serialize_report(_fake_report(ready=True)))
+    assert color == "success"
+    assert "Ready" in str(children)
+
+
+def test_badge_not_ready_critical(rd_app):
+    fn = get_callback_fn(rd_app, "readiness-badge")
+    children, color, _ = fn(_serialize_report(_fake_report(ready=False)))
+    assert color == "danger"
+    assert "0/1 checks" in str(children)
+
+
+def test_badge_not_configured(rd_app):
+    fn = get_callback_fn(rd_app, "readiness-badge")
+    children, color, _ = fn(_empty_readiness_state("No configuration loaded"))
+    assert color == "secondary"
+    assert "Not configured" in str(children)
+
+
+def test_badge_checking_initial(rd_app):
+    fn = get_callback_fn(rd_app, "readiness-badge")
+    children, color, _ = fn({})
+    assert "Checking" in str(children)


### PR DESCRIPTION
Installment 3 of the pytest push (continues #81/#82). Test-only.

- **callbacks/readiness.py -> 66%**: pure helpers (`_serialize_report`,
  `_empty_readiness_state`, `_readiness_fingerprint`, `_readiness_unchanged`) +
  the `render_readiness_badge` renderer across all branches.
- **core/utils/qc_loaders.py 60% -> 65%**: fastp loaders asserted on real
  relationships (before >= after, passed_filter == after, per-sample fan-out
  summing to the aggregate) rather than existence only.

Full suite **2321 passed** (+144 from the 2177 baseline); gate satisfied.

This is where the high/medium-ROI work ends: the remaining uncovered mass is the
background/async callbacks (`preparation_tab.run_preparation`/`export_bundle`,
`startup.check_internet`, `readiness.update_readiness_state`) and subprocess
managers (`nextflow_manager`, `on_demand_validator`), which need
DiskcacheManager/subprocess harnessing and tend toward brittle tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)